### PR TITLE
Release v0.2.1: Documentation, tests, and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main]
   pull_request:
-    branches: [main, master, develop]
+    branches: [main]
+
+env:
+  PYTHON_VERSION: "3.13"
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -17,11 +21,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install dependencies
-        run: |
-          pip install ruff mypy types-requests pytest
+      - name: Install linting tools
+        run: pip install ruff mypy types-requests
 
       - name: Lint with ruff
         run: ruff check app/ tests/
@@ -35,6 +38,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,11 +46,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Run tests
         run: pytest tests/ -v
@@ -54,14 +57,15 @@ jobs:
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build
+      - name: Build Docker image
         run: docker build -t immich-convert-originals:test .
 
-      - name: Test imports
+      - name: Test container starts
         run: |
           docker run --rm --entrypoint python3 immich-convert-originals:test -c \
             "import main; print('imports OK')"

--- a/README.md
+++ b/README.md
@@ -9,72 +9,61 @@ Batch-transcode your Immich library to modern efficient formats:
 
 This tool downloads your original assets, transcodes them to space-efficient formats, uploads the new versions, copies all metadata (EXIF, location, tags, albums, etc.), and removes the originals.
 
----
+## Why This Project?
 
-## Disclaimer & Risks
+Modern image and video formats offer significant space savings without perceptible quality loss. JPEG XL typically reduces image sizes by 20-40% compared to JPEG, while AV1 can reduce video sizes by 30-50% compared to H.264. For large photo libraries, this can mean saving hundreds of gigabytes.
 
-**USE AT YOUR OWN RISK.** This tool modifies your Immich library by:
-- Permanently deleting original assets after successful conversion
-- Replacing them with transcoded versions
+**Goals:**
+- Reduce storage costs for Immich libraries
+- Maintain full metadata and quality
+- Provide a safe, reversible conversion process
 
-**Before using this tool:**
-1. **Backup your Immich library** - Have a complete backup of your original files
-2. **Test on a small subset first** - Use date filters or `MAX_ASSETS` to test with a few assets
-3. **Understand your Immich trash settings** - Deleted assets go to Immich trash first
+## Features
 
----
-
-## About Trash & Recovery
-
-**Good news:** When this tool deletes originals, they go to Immich's **trash**, not permanent deletion.
-
-- Trash items can be restored from the Immich web UI
-- Default trash auto-empty is typically 30 days (configurable in Immich)
-- **Check your Immich trash settings** at `Administration > Settings > Trash`
-- The converted JXL/AV1 files remain in your library immediately
-
-**Recommendation:** After converting, verify a few converted assets before emptying trash.
-
----
-
-## Getting Your Immich API Key
-
-1. Open your Immich web interface
-2. Click your **profile picture** (top right) → **Account Settings**
-3. Go to **API Keys** section
-4. Click **New API Key**
-5. Give it a name (e.g., "Library Converter")
-6. Copy the key immediately (it won't be shown again)
-
-**Required API Key Permissions:**
-- `Asset` - Read, Upload, Delete
-- `Album` - Read
-- `Library` - Read (if using external libraries)
-
----
+- **Image conversion** — JPEG, PNG, WebP, HEIC → JPEG XL
+- **Video conversion** — MP4, MOV, MKV → AV1 (MP4)
+- **Metadata preservation** — EXIF, GPS, tags, albums, faces
+- **Smart retry logic** — automatically retries with higher compression if output is larger
+- **Dry-run mode** — preview changes before executing
+- **Date filtering** — process only assets within a date range
+- **Concurrency control** — configurable parallel workers
 
 ## Quick Start
 
 ```bash
-# 1. Clone or download this repository
+# Clone the repository
+git clone https://github.com/fabianwimberger/immich-convert-originals.git
 cd immich-convert-originals
 
-# 2. Copy and edit configuration
+# Copy and edit configuration
 cp .env.example .env
 # Edit .env with your Immich URL and API key
 
-# 3. Start with dry run to preview
+# Start with dry run to preview
 DRY_RUN=true docker compose up
 
-# 4. When ready, run for real
+# When ready, run for real
 docker compose up
 ```
 
----
+## How It Works
+
+```
+Search assets → Download → Transcode → Upload new → Copy metadata → Delete original
+```
+
+Each step is verified:
+1. **Download** original to temp directory
+2. **Transcode** based on asset type
+3. **Validate** output format and integrity
+4. **Upload** new asset to Immich
+5. **Copy metadata** (EXIF, GPS, tags, albums, faces, etc.)
+6. **Verify** new asset is accessible
+7. **Delete** original (goes to trash, recoverable for 30 days)
+
+If any step fails, the new asset is cleaned up and the original is preserved.
 
 ## Configuration
-
-Only 2 settings are **required**: `IMMICH_API_BASE` and `IMMICH_API_KEY`. Everything else uses sensible defaults (dry-run mode is on by default).
 
 ### Required Settings
 
@@ -85,124 +74,46 @@ Only 2 settings are **required**: `IMMICH_API_BASE` and `IMMICH_API_KEY`. Everyt
 
 **Always start with `DRY_RUN=true` (the default) to test your settings.**
 
-### Optional Settings
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `DRY_RUN` | Preview mode - no changes made | `true` |
-| `ASSET_TYPES` | `IMAGE`, `VIDEO`, or `IMAGE,VIDEO` | `IMAGE,VIDEO` |
-| `CONCURRENCY` | Parallel workers | `1` |
-| `MAX_ASSETS` | Limit number of assets to process (0 = unlimited) | `0` |
-| `INCLUDE_ARCHIVED` | Include archived assets | `false` |
-| `INCLUDE_DELETED` | Include trash assets | `false` |
-
-### Date Filtering
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `FILTER_DATE_AFTER` | Only assets after date (YYYY-MM-DD) | `2020-01-01` |
-| `FILTER_DATE_BEFORE` | Only assets before date (YYYY-MM-DD) | `2023-12-31` |
-
-Leave empty to process all dates.
-
 ### Image Encoding (JPEG XL)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `IMAGE_DISTANCE` | JXL distance (0=lossless, 1=visually lossless, higher=smaller) | `1.0` |
-| `IMAGE_DISTANCE_RETRY` | Distance for retry if output is larger (higher=more compression) | `2.0` |
-
-**How images are encoded:**
-- **JPEG files**: `cjxl` lossless repack (always lossless, distance setting ignored)
-- **PNG/WebP/HEIC/AVIF/TIFF/BMP/GIF/etc**: ImageMagick with `IMAGE_DISTANCE`
-- If `cjxl` fails (progressive JPEG, CMYK), falls back to ImageMagick
+| `IMAGE_DISTANCE` | JXL distance (0=lossless, 1=visually lossless) | `1.0` |
+| `IMAGE_DISTANCE_RETRY` | Distance for retry if output is larger | `2.0` |
 
 ### Video Encoding (AV1)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `VIDEO_CRF` | Quality (0-63, lower=better, larger file) | `36` |
-| `VIDEO_PRESET` | Speed/quality tradeoff (0-13, lower=slower/better) | `4` |
-| `VIDEO_MAX_DIMENSION` | Max shorter side in pixels (0=original size) | `0` |
-| `VIDEO_AUDIO_BITRATE` | Audio bitrate | `64k` |
-| `VIDEO_CRF_RETRY` | CRF for retry if output is larger | `40` |
+| `VIDEO_CRF` | Quality (0-63, lower=better) | `36` |
+| `VIDEO_PRESET` | Speed/quality tradeoff (0-13, lower=slower) | `4` |
+| `VIDEO_MAX_DIMENSION` | Max shorter side in pixels (0=original) | `0` |
 
-**Note:** `VIDEO_MAX_DIMENSION` limits the shorter side (width for portrait, height for landscape). A 1080 setting keeps 1080x1920 portrait videos at full resolution.
+## Security & Safety
 
-### Retry Behavior
+**⚠️ USE AT YOUR OWN RISK.** This tool modifies your Immich library:
+- Permanently deletes original assets after successful conversion
+- Replaced assets go to Immich's **trash** (recoverable for 30 days by default)
 
-When output is larger than input:
+**Before using:**
+1. **Backup your Immich library**
+2. **Test on a small subset first** — use date filters or `MAX_ASSETS`
+3. **Check your Immich trash settings** at `Administration > Settings > Trash`
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ENABLE_RETRY` | Retry with more compression if output is larger | `true` |
-| `ACCEPT_RETRY_OUTPUT` | Accept retry result even if still larger | `false` |
+## Getting Your Immich API Key
 
-**Retry flow:**
-1. First attempt with `IMAGE_DISTANCE` / `VIDEO_CRF`
-2. If output >= input and `ENABLE_RETRY=true`: Retry with retry settings
-3. If still larger and `ACCEPT_RETRY_OUTPUT=false`: Skip file
-4. If still larger and `ACCEPT_RETRY_OUTPUT=true`: Accept the file
+1. Open your Immich web interface
+2. Click your **profile picture** (top right) → **Account Settings**
+3. Go to **API Keys** section
+4. Click **New API Key**
+5. Give it a name (e.g., "Library Converter")
+6. Copy the key immediately (it won't be shown again)
 
-### Safety Settings
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `ALLOW_LARGER` | Keep output even if larger than input | `false` |
-
----
-
-## Supported Input Formats
-
-**Images:** JPEG, PNG, WebP, AVIF, HEIC/HEIF, TIFF, BMP, GIF, and more
-
-**Videos:** MP4, MOV, MKV, WebM, AVI, and any format ffmpeg supports
-
-Already-converted assets (JXL images, AV1 videos) are automatically skipped.
-
----
-
-## How It Works
-
-```
-Search assets -> Download -> Transcode -> Upload new -> Copy metadata -> Delete original
-```
-
-Each step is verified:
-1. **Download** original to temp directory
-2. **Transcode** based on asset type
-3. **Validate** output format and integrity
-4. **Upload** new asset to Immich
-5. **Copy metadata** (EXIF, GPS, tags, albums, faces, etc.)
-6. **Verify** new asset is accessible
-7. **Delete** original (goes to trash)
-
-If any step fails, the new asset is cleaned up and the original is preserved.
-
----
-
-## Troubleshooting
-
-### Configuration error: X is required
-You must set `IMMICH_API_BASE` and `IMMICH_API_KEY` in your `.env` file.
-
-### Assets not being processed
-- Check `ASSET_TYPES` includes your asset type
-- Check date filters aren't too restrictive
-- Try `DRY_RUN=true` to see what's being selected
-
-### Output files larger than input
-- Enable retry: `ENABLE_RETRY=true`
-- More compression: `IMAGE_DISTANCE=2.0` or `VIDEO_CRF=40`
-- Accept larger: `ALLOW_LARGER=true`
-
-### Connection failures
-- Verify `IMMICH_API_BASE` ends with `/api`
-- Check API key has required permissions
-- Ensure Immich is accessible from the container
-
----
+**Required Permissions:**
+- `Asset` — Read, Upload, Delete
+- `Album` — Read
+- `Library` — Read (if using external libraries)
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) file.
+MIT License — see [LICENSE](LICENSE) file.


### PR DESCRIPTION
Documentation
  - docs: standardize README structure and content

Testing
  - feat: add unit tests for config and transcode modules (52 tests)

CI/CD
  - ci: run CI on develop branch
  - ci: bump actions/checkout from 4 to 6 (#1)
  - ci: bump actions/setup-python from 5 to 6 (#2)
