### PR TITLE
Add Docker image publishing to GitHub Container Registry (#4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,7 @@ docker-compose.yml
 __pycache__/
 *.pyc
 *.pyo
+
+# Include license files in Docker image (required for LGPL compliance)
+!DOCKER_LICENSES.md
+!NOTICE

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,80 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-publish.yml'
+      - 'app/**'
+      - 'requirements.txt'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=,suffix=,format=short
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Generate artifact attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Output image digest
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "Image digest: ${{ steps.push.outputs.digest }}"

--- a/DOCKER_LICENSES.md
+++ b/DOCKER_LICENSES.md
@@ -1,0 +1,71 @@
+# Third-Party Licenses
+
+This Docker image contains the following third-party software packages:
+
+## Core Dependencies
+
+### libjxl / libjxl-tools
+- **License:** Apache-2.0 / BSD-3-Clause
+- **Source:** https://github.com/libjxl/libjxl
+- **Description:** JPEG XL image format reference implementation
+
+### ImageMagick
+- **License:** Apache-2.0
+- **Source:** https://github.com/ImageMagick/ImageMagick
+- **Description:** Image manipulation suite
+
+### FFmpeg
+- **License:** LGPL-2.1-or-later
+- **Source:** https://ffmpeg.org/download.html
+- **Description:** Audio/video processing toolkit
+- **Note:** This is dynamically linked as required by LGPL. Source code is available at the URL above.
+
+### ExifTool (perl-image-exiftool)
+- **License:** Artistic-1.0-Perl OR GPL-1.0-or-later
+- **Source:** https://exiftool.org/
+- **Description:** EXIF metadata reader/writer
+
+### Python
+- **License:** PSF-2.0
+- **Source:** https://www.python.org/downloads/source/
+- **Description:** Programming language runtime
+
+## Alpine Linux Base
+
+### Alpine Linux
+- **License:** MIT
+- **Source:** https://alpinelinux.org/downloads/
+- **Description:** Linux distribution
+
+## Source Code Availability
+
+In compliance with open-source license requirements (particularly LGPL for FFmpeg), source code for all included packages can be obtained from:
+
+1. **Alpine Package Repositories:** https://pkgs.alpinelinux.org/packages
+2. **Individual project websites:** Listed above for each package
+
+To extract the exact source packages used in a specific image version:
+
+```bash
+# Run this inside the container to list installed packages
+apk info -v | sort
+
+# Download specific package sources from Alpine
+# Example for libjxl version X.Y.Z:
+# https://pkgs.alpinelinux.org/package/v3.21/community/x86_64/libjxl
+```
+
+## License Texts
+
+Full license texts are included in the image at `/usr/share/licenses/` (where available) or can be found at:
+- Apache-2.0: https://www.apache.org/licenses/LICENSE-2.0
+- BSD-3-Clause: https://opensource.org/licenses/BSD-3-Clause
+- LGPL-2.1: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+- Artistic-1.0-Perl: https://dev.perl.org/licenses/artistic.html
+- GPL-1.0: https://www.gnu.org/licenses/old-licenses/gpl-1.0.html
+- MIT: https://opensource.org/licenses/MIT
+- PSF-2.0: https://docs.python.org/3/license.html
+
+## Trademarks
+
+All trademarks, service marks, and trade names are the property of their respective owners.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.13-alpine
 
+# OCI labels for image metadata
+LABEL org.opencontainers.image.title="Immich Convert Originals"
+LABEL org.opencontainers.image.description="Batch-transcode Immich library to JPEG XL and AV1"
+LABEL org.opencontainers.image.source="https://github.com/fabianwimberger/immich-convert-originals"
+LABEL org.opencontainers.image.licenses="MIT"
+
 ENV PYTHONUNBUFFERED=1
 
 RUN apk add --no-cache \
@@ -18,6 +24,9 @@ RUN mkdir -p /work/in /work/out && \
 
 COPY app /app
 RUN chown -R appuser:appuser /app
+
+# Copy license files for compliance
+COPY NOTICE DOCKER_LICENSES.md /app/
 
 WORKDIR /app
 USER appuser

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+Immich Convert Originals
+Copyright (c) 2026 Fabian Wimberger
+
+This product includes software developed by third parties.
+See DOCKER_LICENSES.md for complete license information.
+
+THIRD-PARTY COMPONENTS
+======================
+
+This Docker image contains the following third-party software:
+
+- libjxl / libjxl-tools (Apache-2.0 / BSD-3-Clause)
+  https://github.com/libjxl/libjxl
+
+- ImageMagick (Apache-2.0)
+  https://imagemagick.org/
+
+- FFmpeg (LGPL-2.1-or-later)
+  https://ffmpeg.org/
+  Source code available at: https://ffmpeg.org/download.html
+
+- ExifTool / perl-image-exiftool (Artistic-1.0-Perl OR GPL-1.0-or-later)
+  https://exiftool.org/
+
+- Python (PSF-2.0)
+  https://www.python.org/
+
+- Alpine Linux (MIT)
+  https://alpinelinux.org/
+
+The source code for LGPL-licensed components (FFmpeg) is available
+from the project websites listed above or the Alpine Linux package
+repositories at https://pkgs.alpinelinux.org/
+
+This software is provided "as is" without warranty of any kind.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Immich Library Converter
 
 [![CI](https://github.com/fabianwimberger/immich-convert-originals/actions/workflows/ci.yml/badge.svg)](https://github.com/fabianwimberger/immich-convert-originals/actions)
+[![Docker](https://github.com/fabianwimberger/immich-convert-originals/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/fabianwimberger/immich-convert-originals/pkgs/container/immich-convert-originals)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Batch-transcode your Immich library to modern efficient formats:
@@ -29,6 +30,31 @@ Modern image and video formats offer significant space savings without perceptib
 - **Concurrency control** — configurable parallel workers
 
 ## Quick Start
+
+### Option 1: Prebuilt Docker Image (Recommended)
+
+The easiest way to run the tool is using the prebuilt image from GitHub Container Registry:
+
+```bash
+# Create a directory for your configuration
+mkdir immich-converter && cd immich-converter
+
+# Download the example environment file
+curl -O https://raw.githubusercontent.com/fabianwimberger/immich-convert-originals/main/.env.example
+mv .env.example .env
+
+# Edit .env with your Immich URL and API key
+nano .env
+
+# Run with dry run first to preview
+docker run --rm --env-file .env ghcr.io/fabianwimberger/immich-convert-originals:main
+
+# When ready, disable dry run and run for real
+# Edit .env: set DRY_RUN=false
+docker run --rm --env-file .env ghcr.io/fabianwimberger/immich-convert-originals:main
+```
+
+### Option 2: Docker Compose (Build Locally)
 
 ```bash
 # Clone the repository
@@ -114,6 +140,19 @@ If any step fails, the new asset is cleaned up and the original is preserved.
 - `Album` — Read
 - `Library` — Read (if using external libraries)
 
+## Docker Image Tags
+
+The following image tags are available from `ghcr.io/fabianwimberger/immich-convert-originals`:
+
+| Tag | Description |
+|-----|-------------|
+| `main` | Latest development build from main branch |
+| `v1.2.3` | Specific release version |
+| `v1.2` | Latest patch release in the v1.2.x series |
+| `v1` | Latest minor release in the v1.x.x series |
+
 ## License
 
 MIT License — see [LICENSE](LICENSE) file.
+
+This project includes third-party software. See [DOCKER_LICENSES.md](DOCKER_LICENSES.md) for license information about dependencies included in the Docker image.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
 services:
   immich-library-converter:
+    # Option 1: Build locally (default)
     build: .
     image: immich-library-converter:local
+
+    # Option 2: Use prebuilt image from GitHub Container Registry
+    # Uncomment the line below and comment out the 'build' and 'image' lines above
+    # image: ghcr.io/fabianwimberger/immich-convert-originals:main
+
     container_name: immich-library-converter
     env_file:
       - .env


### PR DESCRIPTION
* docs: add third-party license documentation for Docker distribution

  Add DOCKER_LICENSES.md and NOTICE files documenting all dependencies
  included in the Docker image. Required for LGPL compliance (FFmpeg)
  and general open-source license transparency.

* ci: add Docker publish workflow for GitHub Container Registry

  Build and push multi-platform images (amd64, arm64) to ghcr.io on:
  - pushes to main branch
  - version tags (v*)
  - PRs affecting Dockerfile (for testing)

* build: add OCI labels and license files to Docker image

  - Add OCI image metadata labels
  - Copy license files into image for LGPL compliance

* docs: document prebuilt Docker image usage

  Add instructions for using ghcr.io/fabianwimberger/immich-convert-originals
  and update docker-compose.yml with commented prebuilt image option.