### PR TITLE
ci: add codecov config with patch threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 25%
+    project:
+      default:
+        target: auto
+        threshold: 5%


### PR DESCRIPTION
## What changed

Add codecov.yml to set a 25% patch threshold and 5% project threshold, preventing CI from blocking on uncovered patch lines.

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes