### PR TITLE
deps: bump tqdm, responses, setuptools, ruff, mypy, and actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Restore Immich image cache
         id: img-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/immich-image-cache
           key: immich-images-${{ env.IMMICH_TEST_TAG }}-postgres-vectorchord0.4.3-valkey-9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,8 +15,8 @@ dev = [
     "pytest>=9.1.1",
     "pytest-cov>=7.0.0",
     "responses>=0.26.1",
-    "ruff>=0.15.18",
-    "mypy>=2.1.0",
+    "ruff>=0.15.21",
+    "mypy>=2.2.0",
     "types-requests>=2.33.0.20260518",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 pytest==9.1.1
 pytest-cov==7.1.0
-responses==0.26.1
+responses==0.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.34.2
-tqdm==4.68.3
+tqdm==4.68.4
 questionary==2.1.1


### PR DESCRIPTION
## Summary
- tqdm 4.68.3 -> 4.68.4 (#63), responses 0.26.1 -> 0.26.2 (#62), setuptools floor 82.0.1 -> 83.0.0 (#61), ruff floor 0.15.18 -> 0.15.21 (#65), mypy floor 2.1.0 -> 2.2.0 (#64), actions/cache v5 -> v6 (#59)
- Closing #59, #61, #62, #63, #64, #65 as superseded

## Test plan
- [x] `pip install -r requirements-dev.txt` resolves cleanly
- [x] `pytest -q --cov` -> 246 passed (2 pre-existing integration test errors due to `exiftool` not being installed in this local environment, unrelated to this change — CI installs it as a system dependency)
- [x] `ruff check .` -> clean
- [x] `mypy app` -> no issues