### PR TITLE
fix: restore Immich v3 API compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.13"
-  IMMICH_TEST_TAG_PINNED: "v2.7.5"
+  IMMICH_TEST_TAG_PINNED: "v3.0.3"
 
 jobs:
   lint:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      IMMICH_TEST_TAG: v2.7.5
+      IMMICH_TEST_TAG: v3.0.3
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/app/immich_api.py
+++ b/app/immich_api.py
@@ -452,9 +452,7 @@ class ImmichClient:
             }
             response = self._request_with_retry("POST", url, json=body)
             if response.status_code != 200:
-                raise RuntimeError(
-                    f"Failed to get album: HTTP {response.status_code}"
-                )
+                raise RuntimeError(f"Failed to get album: HTTP {response.status_code}")
             items = response.json().get("assets", {}).get("items", [])
             if not items:
                 break

--- a/app/immich_api.py
+++ b/app/immich_api.py
@@ -21,8 +21,6 @@ class Asset:
     original_path: str
     original_mime_type: str | None
     type: str
-    device_asset_id: str
-    device_id: str
     file_created_at: str
     file_modified_at: str
 
@@ -34,8 +32,6 @@ class Asset:
             original_path=data["originalPath"],
             original_mime_type=data.get("originalMimeType"),
             type=data["type"],
-            device_asset_id=data["deviceAssetId"],
-            device_id=data["deviceId"],
             file_created_at=data["fileCreatedAt"],
             file_modified_at=data["fileModifiedAt"],
         )
@@ -140,9 +136,14 @@ class ImmichClient:
             "page": page,
             "size": size,
             "order": "asc",
-            "withArchived": with_archived,
             "withDeleted": with_deleted,
         }
+        if not with_archived:
+            # Immich has no "exclude archived" flag; restrict to timeline
+            # visibility instead. Omitting this when with_archived=True
+            # returns everything except locked (pin-protected) assets,
+            # which this tool must never touch.
+            body["visibility"] = "timeline"
 
         if original_filename:
             body["originalFileName"] = original_filename
@@ -246,8 +247,6 @@ class ImmichClient:
     def upload_asset(
         self,
         file_path: str,
-        device_asset_id: str,
-        device_id: str,
         file_created_at: str,
         file_modified_at: str,
         filename: str | None = None,
@@ -256,8 +255,6 @@ class ImmichClient:
         url = urljoin(self.api_base, "assets")
 
         data = {
-            "deviceAssetId": device_asset_id,
-            "deviceId": device_id,
             "fileCreatedAt": file_created_at,
             "fileModifiedAt": file_modified_at,
         }
@@ -324,7 +321,8 @@ class ImmichClient:
         from_asset_id: str,
         to_asset_id: str,
     ) -> tuple[bool, str | None]:
-        """Copy asset metadata (favorite, archive, albums) from one asset to another."""
+        """Copy asset metadata (favorite, visibility, rating, albums, stack)
+        from one asset to another."""
         # 1. Fetch source asset details
         source_url = urljoin(self.api_base, f"assets/{from_asset_id}")
         try:
@@ -337,14 +335,18 @@ class ImmichClient:
         except Exception as e:
             return False, str(e)
 
-        # 2. Bulk-update target asset with favorite / archive status.
+        # 2. Bulk-update target asset with favorite / visibility / rating.
         #    Only include fields that were explicitly present in the source
         #    so we don't reset state when the API omits keys.
         update_url = urljoin(self.api_base, "assets")
         update_body: dict[str, Any] = {"ids": [to_asset_id]}
-        for key in ("isFavorite", "isArchived", "isTrashed", "rating"):
+        for key in ("isFavorite", "visibility"):
             if key in source_data:
                 update_body[key] = source_data[key]
+        if "rating" in source_data:
+            rating = source_data["rating"]
+            # 0 and -1 are no longer valid rating values; unrated is null.
+            update_body["rating"] = rating if rating and 1 <= rating <= 5 else None
 
         if len(update_body) > 1:  # ids is always present
             try:
@@ -363,37 +365,30 @@ class ImmichClient:
             except Exception as e:
                 return False, str(e)
 
-        # 3. Add target asset to each of the source's albums
-        album_errors: list[str] = []
-        albums_url = urljoin(self.api_base, "albums")
+        # 3. Copy album and stack associations from source to target.
+        copy_url = urljoin(self.api_base, "assets/copy")
+        copy_body = {
+            "sourceId": from_asset_id,
+            "targetId": to_asset_id,
+            "albums": True,
+            "stack": True,
+            "favorite": False,
+            "sharedLinks": False,
+            "sidecar": False,
+        }
         try:
-            albums_resp = self._request_with_retry(
-                "GET", albums_url, params={"assetId": from_asset_id}
-            )
-            if albums_resp.status_code == 200:
-                albums = albums_resp.json()
-                for album in albums:
-                    album_id = album.get("id")
-                    if not album_id:
-                        continue
-                    album_url = urljoin(self.api_base, f"albums/{album_id}/assets")
-                    try:
-                        album_resp = self._request_with_retry(
-                            "PUT", album_url, json={"ids": [to_asset_id]}
-                        )
-                        if album_resp.status_code not in (200, 204):
-                            album_name = album.get("albumName", "unknown")
-                            album_errors.append(
-                                f"album '{album_name}': HTTP {album_resp.status_code}"
-                            )
-                    except Exception as e:
-                        album_name = album.get("albumName", "unknown")
-                        album_errors.append(f"album '{album_name}': {e}")
+            copy_resp = self._request_with_retry("PUT", copy_url, json=copy_body)
+            if copy_resp.status_code not in (200, 204):
+                try:
+                    error_detail = copy_resp.json()
+                    error_msg = error_detail.get("message", str(error_detail))
+                except Exception:
+                    error_msg = copy_resp.text or "Unknown error"
+                return False, (
+                    f"Album copy failed: HTTP {copy_resp.status_code} - {error_msg}"
+                )
         except Exception as e:
-            album_errors.append(f"fetch albums: {e}")
-
-        if album_errors:
-            return False, f"Album copy failed: {'; '.join(album_errors)}"
+            return False, f"Album copy failed: {e}"
 
         return True, None
 
@@ -439,11 +434,30 @@ class ImmichClient:
         return albums
 
     def get_album_assets(self, album_id: str) -> list[Asset]:
-        """Get all assets from a specific album."""
-        url = urljoin(self.api_base, f"albums/{album_id}")
-        response = self._request_with_retry("GET", url)
-        if response.status_code != 200:
-            raise RuntimeError(f"Failed to get album: HTTP {response.status_code}")
-        data = response.json()
-        items = data.get("assets", [])
-        return [Asset.from_dict(item) for item in items]
+        """Get all assets from a specific album.
+
+        Immich no longer returns an `assets` array from GET /albums/{id};
+        the album's assets must be fetched via search instead.
+        """
+        url = urljoin(self.api_base, "search/metadata")
+        assets: list[Asset] = []
+        page = 1
+        while True:
+            body = {
+                "albumIds": [album_id],
+                "page": page,
+                "size": 500,
+                "order": "asc",
+                "withDeleted": True,
+            }
+            response = self._request_with_retry("POST", url, json=body)
+            if response.status_code != 200:
+                raise RuntimeError(
+                    f"Failed to get album: HTTP {response.status_code}"
+                )
+            items = response.json().get("assets", {}).get("items", [])
+            if not items:
+                break
+            assets.extend(Asset.from_dict(item) for item in items)
+            page += 1
+        return assets

--- a/app/main.py
+++ b/app/main.py
@@ -262,13 +262,10 @@ def process_asset(asset: Asset, client: ImmichClient, config: Config) -> dict:
         # Replace: upload -> copy metadata -> verify -> delete original
         base_name = os.path.splitext(asset.original_file_name)[0]
         new_filename = f"{base_name}.{target_format}"
-        new_device_asset_id = f"{asset.id}-{target_format}"
 
         t = time.monotonic()
         new_asset_id, error = client.upload_asset(
             file_path=output_path,
-            device_asset_id=new_device_asset_id,
-            device_id=asset.device_id,
             file_created_at=asset.file_created_at,
             file_modified_at=asset.file_modified_at,
             filename=new_filename,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "immich-convert-originals"
-version = "1.1.1"
+version = "1.2.0"
 requires-python = ">=3.13"
 dependencies = [
     "requests>=2.34.2",

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -3,11 +3,11 @@ name: immich-convert-test
 services:
   immich-test-server:
     container_name: immich-test-server
-    image: ghcr.io/immich-app/immich-server:${IMMICH_TEST_TAG:-v2.7.5}
+    image: ghcr.io/immich-app/immich-server:${IMMICH_TEST_TAG:-v3.0.3}
     ports:
       - "127.0.0.1:${IMMICH_TEST_PORT}:2283"
     environment:
-      IMMICH_VERSION: ${IMMICH_TEST_TAG:-v2.7.5}
+      IMMICH_VERSION: ${IMMICH_TEST_TAG:-v3.0.3}
       DB_HOSTNAME: immich-test-postgres
       DB_PORT: 5432
       DB_USERNAME: postgres

--- a/tests/integration/seeder.py
+++ b/tests/integration/seeder.py
@@ -1,7 +1,6 @@
 """Seed a test library into a real Immich instance."""
 
 import subprocess
-import uuid
 from pathlib import Path
 from typing import Any
 
@@ -9,7 +8,6 @@ import requests
 
 from app.immich_api import ImmichClient
 
-DEVICE_ID = "integration-test-device"
 SEED_MARKER_ALBUM = "__immich-convert-seed-marker__"
 IMAGE_NAMES = (
     "sample.jpg",
@@ -216,11 +214,8 @@ def _generate_media(fixtures_dir: Path, tmp_dir: Path) -> dict[str, Path]:
 def _upload_asset(
     client: ImmichClient, path: Path, filename: str, created_at: str
 ) -> str:
-    device_asset_id = f"{filename}-{uuid.uuid4()}"
     asset_id, error = client.upload_asset(
         file_path=str(path),
-        device_asset_id=device_asset_id,
-        device_id=DEVICE_ID,
         file_created_at=created_at,
         file_modified_at=created_at,
         filename=filename,
@@ -373,7 +368,10 @@ def seed_library(client: ImmichClient, tmp_path_factory: Any) -> dict[str, Any]:
         client.api_base, client.api_key, [image_ids["sample.jpg"]], isFavorite=True
     )
     _update_assets(
-        client.api_base, client.api_key, [image_ids["sample.heic"]], isArchived=True
+        client.api_base,
+        client.api_key,
+        [image_ids["sample.heic"]],
+        visibility="archive",
     )
 
     # Drop a marker album so future sessions can short-circuit the seed.

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -202,14 +202,10 @@ class TestEndToEnd:
             "Artist tag not preserved"
         )
 
-        # Verify album membership by querying the album
-        album_url = f"{admin_client.api_base}albums/{lib['albums']['vacation']}"
-        album_resp = requests.get(
-            album_url, headers=admin_client._default_headers, timeout=10
-        )
-        assert album_resp.status_code == 200
-        album_data = album_resp.json()
-        album_asset_ids = {a["id"] for a in album_data.get("assets", [])}
+        # Verify album membership via search (GET /albums/{id} no longer
+        # returns an `assets` array).
+        album_assets = admin_client.get_album_assets(lib["albums"]["vacation"])
+        album_asset_ids = {a.id for a in album_assets}
         assert new_jxl.id in album_asset_ids
 
         # 3. Happy path: convert one video (h264.mp4)
@@ -382,8 +378,6 @@ def test_upload_failure_rollback(
     import uuid as _uuid
     from pathlib import Path as _Path
 
-    from tests.integration.seeder import DEVICE_ID
-
     _ = seeded_library  # fixture dependency only.
 
     # Upload a fresh JPEG out-of-band so this test is independent of other
@@ -395,8 +389,6 @@ def test_upload_failure_rollback(
 
     fresh_id, err = admin_client.upload_asset(
         file_path=str(target_path),
-        device_asset_id=f"{unique_name}-{_uuid.uuid4()}",
-        device_id=DEVICE_ID,
         file_created_at="2017-05-05T00:00:00Z",
         file_modified_at="2017-05-05T00:00:00Z",
         filename=unique_name,

--- a/tests/test_immich_api.py
+++ b/tests/test_immich_api.py
@@ -27,8 +27,6 @@ class TestAssetFromDict:
             "originalPath": "/uploads/photo.jpg",
             "originalMimeType": "image/jpeg",
             "type": "IMAGE",
-            "deviceAssetId": "device-1",
-            "deviceId": "phone-1",
             "fileCreatedAt": "2023-01-01T00:00:00Z",
             "fileModifiedAt": "2023-01-01T00:00:00Z",
         }
@@ -43,8 +41,6 @@ class TestAssetFromDict:
             "originalFileName": "photo.jpg",
             "originalPath": "/uploads/photo.jpg",
             "type": "IMAGE",
-            "deviceAssetId": "device-1",
-            "deviceId": "phone-1",
             "fileCreatedAt": "2023-01-01T00:00:00Z",
             "fileModifiedAt": "2023-01-01T00:00:00Z",
         }
@@ -58,8 +54,6 @@ class TestAssetFromDict:
             "originalPath": None,
             "originalMimeType": "image/jpeg",
             "type": "VIDEO",
-            "deviceAssetId": "d1",
-            "deviceId": "p1",
             "fileCreatedAt": "2023-01-01T00:00:00Z",
             "fileModifiedAt": "2023-01-01T00:00:00Z",
         }
@@ -147,8 +141,8 @@ class TestSearchAssets:
             "page": 2,
             "size": 100,
             "order": "asc",
-            "withArchived": False,
             "withDeleted": False,
+            "visibility": "timeline",
         }
 
     @responses.activate
@@ -200,7 +194,7 @@ class TestSearchAssets:
         assert body["originalPath"] == "/uploads/x.jpg"
 
     @responses.activate
-    def test_archived_and_deleted_flags_passed_through(self, client):
+    def test_deleted_flag_passed_through(self, client):
         responses.add(
             responses.POST,
             "https://example.com/api/search/metadata",
@@ -214,8 +208,29 @@ class TestSearchAssets:
             with_deleted=True,
         )
         body = json.loads(responses.calls[0].request.body)
-        assert body["withArchived"] is True
         assert body["withDeleted"] is True
+
+    @responses.activate
+    def test_with_archived_true_omits_visibility_filter(self, client):
+        responses.add(
+            responses.POST,
+            "https://example.com/api/search/metadata",
+            json={"assets": {"items": []}},
+        )
+        client.search_assets(page=1, size=10, asset_type="IMAGE", with_archived=True)
+        body = json.loads(responses.calls[0].request.body)
+        assert "visibility" not in body
+
+    @responses.activate
+    def test_with_archived_false_restricts_to_timeline(self, client):
+        responses.add(
+            responses.POST,
+            "https://example.com/api/search/metadata",
+            json={"assets": {"items": []}},
+        )
+        client.search_assets(page=1, size=10, asset_type="IMAGE", with_archived=False)
+        body = json.loads(responses.calls[0].request.body)
+        assert body["visibility"] == "timeline"
 
     @responses.activate
     def test_returns_asset_dataclasses(self, client):
@@ -231,8 +246,6 @@ class TestSearchAssets:
                             "originalPath": "/p/x.jpg",
                             "originalMimeType": "image/jpeg",
                             "type": "IMAGE",
-                            "deviceAssetId": "d1",
-                            "deviceId": "p1",
                             "fileCreatedAt": "2023-01-01T00:00:00Z",
                             "fileModifiedAt": "2023-01-01T00:00:00Z",
                         }
@@ -308,8 +321,6 @@ class TestUploadAsset:
         file_path.write_bytes(b"data")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="da1",
-            device_id="phone1",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
             filename="upload.bin",
@@ -331,8 +342,6 @@ class TestUploadAsset:
         file_path.write_bytes(b"data")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="da1",
-            device_id="phone1",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -351,8 +360,6 @@ class TestUploadAsset:
         file_path.write_bytes(b"data")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="da1",
-            device_id="phone1",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -371,8 +378,6 @@ class TestUploadAsset:
         file_path.write_bytes(b"data")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="da1",
-            device_id="phone1",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -386,43 +391,58 @@ class TestCopyAssetData:
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={
-                "id": "src",
-                "isFavorite": True,
-                "isArchived": False,
-                "albums": [{"id": "album-1"}],
-            },
+            json={"id": "src", "isFavorite": True, "visibility": "timeline"},
         )
         responses.add(responses.PUT, "https://example.com/api/assets", status=204)
-        responses.add(
-            responses.GET,
-            "https://example.com/api/albums",
-            json=[{"id": "album-1", "albumName": "Test"}],
-        )
-        responses.add(
-            responses.PUT,
-            "https://example.com/api/albums/album-1/assets",
-            status=204,
-        )
+        responses.add(responses.PUT, "https://example.com/api/assets/copy", status=204)
         success, error = client.copy_asset_data("src", "dst")
         assert success is True
         assert error is None
 
+        update_body = json.loads(responses.calls[1].request.body)
+        assert update_body == {
+            "ids": ["dst"],
+            "isFavorite": True,
+            "visibility": "timeline",
+        }
+        copy_body = json.loads(responses.calls[2].request.body)
+        assert copy_body == {
+            "sourceId": "src",
+            "targetId": "dst",
+            "albums": True,
+            "stack": True,
+            "favorite": False,
+            "sharedLinks": False,
+            "sidecar": False,
+        }
+
     @responses.activate
-    def test_no_albums(self, client):
+    def test_rating_zero_sent_as_null(self, client):
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={"id": "src", "isFavorite": False, "isArchived": False, "albums": []},
+            json={"id": "src", "isFavorite": False, "rating": 0},
         )
         responses.add(responses.PUT, "https://example.com/api/assets", status=204)
-        responses.add(
-            responses.GET,
-            "https://example.com/api/albums",
-            json=[],
-        )
+        responses.add(responses.PUT, "https://example.com/api/assets/copy", status=204)
         success, error = client.copy_asset_data("src", "dst")
         assert success is True
+        update_body = json.loads(responses.calls[1].request.body)
+        assert update_body["rating"] is None
+
+    @responses.activate
+    def test_rating_in_range_passed_through(self, client):
+        responses.add(
+            responses.GET,
+            "https://example.com/api/assets/src",
+            json={"id": "src", "isFavorite": False, "rating": 4},
+        )
+        responses.add(responses.PUT, "https://example.com/api/assets", status=204)
+        responses.add(responses.PUT, "https://example.com/api/assets/copy", status=204)
+        success, error = client.copy_asset_data("src", "dst")
+        assert success is True
+        update_body = json.loads(responses.calls[1].request.body)
+        assert update_body["rating"] == 4
 
     @responses.activate
     def test_source_not_found(self, client):
@@ -436,7 +456,7 @@ class TestCopyAssetData:
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={"id": "src", "isFavorite": False, "isArchived": False, "albums": []},
+            json={"id": "src", "isFavorite": False, "visibility": "timeline"},
         )
         responses.add(
             responses.PUT,
@@ -541,8 +561,6 @@ class TestUploadAssetAuthErrors:
         file_path.write_bytes(b"x")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="d",
-            device_id="p",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -556,8 +574,6 @@ class TestUploadAssetAuthErrors:
         file_path.write_bytes(b"x")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="d",
-            device_id="p",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -576,8 +592,6 @@ class TestUploadAssetAuthErrors:
         file_path.write_bytes(b"x")
         asset_id, error = client.upload_asset(
             file_path=str(file_path),
-            device_asset_id="d",
-            device_id="p",
             file_created_at="2023-01-01T00:00:00Z",
             file_modified_at="2023-01-01T00:00:00Z",
         )
@@ -587,42 +601,47 @@ class TestUploadAssetAuthErrors:
 
 class TestCopyAssetDataAlbums:
     @responses.activate
-    def test_album_sync_reports_errors(self, client):
+    def test_copy_endpoint_reports_json_error(self, client):
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={"id": "src", "isFavorite": False, "isArchived": False},
+            json={"id": "src", "isFavorite": False},
         )
         responses.add(responses.PUT, "https://example.com/api/assets", status=204)
         responses.add(
-            responses.GET,
-            "https://example.com/api/albums",
-            json=[
-                {"id": "album-1", "albumName": "A1"},
-                {"id": ""},
-                {"id": "album-2", "albumName": "A2"},
-            ],
-        )
-        responses.add(
             responses.PUT,
-            "https://example.com/api/albums/album-1/assets",
-            status=500,
-        )
-        responses.add(
-            responses.PUT,
-            "https://example.com/api/albums/album-2/assets",
-            status=204,
+            "https://example.com/api/assets/copy",
+            json={"message": "Bad request"},
+            status=400,
         )
         ok, error = client.copy_asset_data("src", "dst")
         assert ok is False
-        assert "album 'A1': HTTP 500" in error
+        assert "Bad request" in error
+
+    @responses.activate
+    def test_copy_endpoint_falls_back_to_text(self, client):
+        responses.add(
+            responses.GET,
+            "https://example.com/api/assets/src",
+            json={"id": "src", "isFavorite": False},
+        )
+        responses.add(responses.PUT, "https://example.com/api/assets", status=204)
+        responses.add(
+            responses.PUT,
+            "https://example.com/api/assets/copy",
+            body="plain text failure",
+            status=500,
+        )
+        ok, error = client.copy_asset_data("src", "dst")
+        assert ok is False
+        assert "plain text failure" in error
 
     @responses.activate
     def test_update_error_falls_back_to_text(self, client):
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={"id": "src", "isFavorite": False, "isArchived": False},
+            json={"id": "src", "isFavorite": False},
         )
         responses.add(
             responses.PUT,
@@ -640,7 +659,7 @@ class TestCopyAssetDataAlbums:
         responses.add(
             responses.GET,
             "https://example.com/api/assets/src",
-            json={"id": "src", "isFavorite": False, "isArchived": False},
+            json={"id": "src", "isFavorite": False},
         )
         responses.add(
             responses.PUT,
@@ -650,6 +669,24 @@ class TestCopyAssetDataAlbums:
         ok, error = client.copy_asset_data("src", "dst")
         assert ok is False
         assert "update-boom" in error or "Request failed" in error
+
+    @responses.activate
+    def test_copy_endpoint_network_exception(self, client, monkeypatch):
+        monkeypatch.setattr("app.immich_api.time.sleep", lambda s: None)
+        responses.add(
+            responses.GET,
+            "https://example.com/api/assets/src",
+            json={"id": "src", "isFavorite": False},
+        )
+        responses.add(responses.PUT, "https://example.com/api/assets", status=204)
+        responses.add(
+            responses.PUT,
+            "https://example.com/api/assets/copy",
+            body=requests.ConnectionError("copy-boom"),
+        )
+        ok, error = client.copy_asset_data("src", "dst")
+        assert ok is False
+        assert "copy-boom" in error or "Album copy failed" in error
 
 
 class TestDownloadOriginalException:
@@ -670,31 +707,67 @@ class TestGetAlbumAssets:
     @responses.activate
     def test_happy_path(self, client):
         responses.add(
-            responses.GET,
-            "https://example.com/api/albums/album-1",
+            responses.POST,
+            "https://example.com/api/search/metadata",
             json={
-                "assets": [
-                    {
-                        "id": "a1",
-                        "originalFileName": "x.jpg",
-                        "originalPath": "/p/x.jpg",
-                        "type": "IMAGE",
-                        "deviceAssetId": "d1",
-                        "deviceId": "p1",
-                        "fileCreatedAt": "2023-01-01T00:00:00Z",
-                        "fileModifiedAt": "2023-01-01T00:00:00Z",
-                    }
-                ]
+                "assets": {
+                    "items": [
+                        {
+                            "id": "a1",
+                            "originalFileName": "x.jpg",
+                            "originalPath": "/p/x.jpg",
+                            "type": "IMAGE",
+                            "fileCreatedAt": "2023-01-01T00:00:00Z",
+                            "fileModifiedAt": "2023-01-01T00:00:00Z",
+                        }
+                    ]
+                }
             },
+        )
+        responses.add(
+            responses.POST,
+            "https://example.com/api/search/metadata",
+            json={"assets": {"items": []}},
         )
         result = client.get_album_assets("album-1")
         assert len(result) == 1
         assert result[0].id == "a1"
+        body = json.loads(responses.calls[0].request.body)
+        assert body["albumIds"] == ["album-1"]
+
+    @responses.activate
+    def test_paginates_until_empty(self, client):
+        responses.add(
+            responses.POST,
+            "https://example.com/api/search/metadata",
+            json={
+                "assets": {
+                    "items": [
+                        {
+                            "id": "a1",
+                            "originalFileName": "x.jpg",
+                            "originalPath": "/p/x.jpg",
+                            "type": "IMAGE",
+                            "fileCreatedAt": "2023-01-01T00:00:00Z",
+                            "fileModifiedAt": "2023-01-01T00:00:00Z",
+                        }
+                    ]
+                }
+            },
+        )
+        responses.add(
+            responses.POST,
+            "https://example.com/api/search/metadata",
+            json={"assets": {"items": []}},
+        )
+        result = client.get_album_assets("album-1")
+        assert len(result) == 1
+        assert len(responses.calls) == 2
 
     @responses.activate
     def test_error_raises(self, client):
         responses.add(
-            responses.GET, "https://example.com/api/albums/album-1", status=404
+            responses.POST, "https://example.com/api/search/metadata", status=404
         )
         with pytest.raises(RuntimeError, match="Failed to get album: HTTP 404"):
             client.get_album_assets("album-1")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,8 +11,6 @@ class FakeAsset:
         self.type = kwargs.get("type", "IMAGE")
         self.original_file_name = kwargs.get("original_file_name", "x.jpg")
         self.original_mime_type = kwargs.get("original_mime_type", "image/jpeg")
-        self.device_id = kwargs.get("device_id", "phone1")
-        self.device_asset_id = kwargs.get("device_asset_id", "da1")
         self.file_created_at = kwargs.get("file_created_at", "2023-01-01T00:00:00Z")
         self.file_modified_at = kwargs.get("file_modified_at", "2023-01-01T00:00:00Z")
 

--- a/tests/test_main_orchestration.py
+++ b/tests/test_main_orchestration.py
@@ -50,8 +50,6 @@ def _make_asset(
         original_path="/uploads/" + file_name,
         original_mime_type=mime_type,
         type=asset_type,
-        device_asset_id="da1",
-        device_id="phone1",
         file_created_at="2023-01-01T00:00:00Z",
         file_modified_at="2023-01-01T00:00:00Z",
     )


### PR DESCRIPTION
## Summary
- Immich v3 removed `deviceAssetId`/`deviceId`, dropped `withArchived` in favor of a `visibility` enum, and removed the `assets` array from `GET /albums/{id}` — all of which broke this tool. Confirmed via the scheduled `Integration Tests (Immich :release)` CI job, which was already red with `KeyError: 'deviceAssetId'`.
- `app/immich_api.py` updated to match the v3 schema; `copy_asset_data` now uses `visibility` and `PUT /assets/copy` instead of a manual per-album loop; `get_album_assets` rebuilt on `POST /search/metadata` with `albumIds` (fixes a silent data-loss bug where `FILTER_ALBUM_ID` returned zero assets on v3).
- Verified backward-compatible with v2.7.5 by diffing both OpenAPI specs — no version branching needed.
- Version bumped to 1.2.0 (public `ImmichClient` method signatures changed).

## Test plan
- [x] Unit suite: 252 passed, `ruff check`/`ruff format --check`/`mypy` clean
- [x] Integration suite run against a live Immich **v3.0.3** Docker stack — full pipeline and rollback tests both pass
- [x] CI green on `develop` (this PR)