### PR TITLE
fix: app freezing under fast-skip runs

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -2,12 +2,28 @@
 
 from collections.abc import AsyncGenerator
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 
 from app.config import settings
 
 engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
+
+
+@event.listens_for(engine.sync_engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record) -> None:
+    """WAL lets readers proceed while a run's writes are in flight, instead
+    of the default rollback-journal mode where every write locks the whole
+    file against readers and other writers. busy_timeout makes a writer
+    that does hit contention retry instead of failing immediately with
+    "database is locked"."""
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA synchronous=NORMAL")
+    cursor.execute("PRAGMA busy_timeout=5000")
+    cursor.close()
+
 
 AsyncSessionLocal = async_sessionmaker(
     engine,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,11 +23,12 @@ async def lifespan(app: FastAPI):
     settings.ensure_directories()
 
     from app.database import init_db
-    from app.services.lifecycle import seed_settings
+    from app.services.lifecycle import reconcile_interrupted_runs, seed_settings
     from app.services.run_queue import run_queue
 
     await init_db()
     await seed_settings()
+    await reconcile_interrupted_runs()
     await run_queue.start()
 
     yield

--- a/backend/app/services/lifecycle.py
+++ b/backend/app/services/lifecycle.py
@@ -1,11 +1,13 @@
 """Startup tasks: run once when the app boots."""
 
 import logging
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 
 from app.config import seed_settings_from_env
 from app.database import AsyncSessionLocal
+from app.models.run import Run
 from app.models.settings import SETTINGS_ROW_ID, Settings
 
 logger = logging.getLogger(__name__)
@@ -29,3 +31,32 @@ async def seed_settings() -> None:
         db.add(row)
         await db.commit()
         logger.info("Seeded settings from environment variables")
+
+
+async def reconcile_interrupted_runs() -> None:
+    """Fail any run left "queued"/"running" by a previous process.
+
+    Nothing re-enqueues a pending run into run_queue on boot, and nothing
+    else ever moves a run out of "running" once its process is gone -- a
+    kill/crash/OOM mid-run otherwise leaves it stuck in that state forever,
+    permanently blocking retry-failed for it.
+    """
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(Run).where(Run.status.in_(("queued", "running")))
+        )
+        stale_runs = result.scalars().all()
+        if not stale_runs:
+            return
+
+        now = datetime.now(timezone.utc)
+        for run in stale_runs:
+            run.status = "failed"
+            run.completed_at = now
+            run.error_message = "Interrupted by application restart"
+        await db.commit()
+        logger.warning(
+            "Marked %d interrupted run(s) as failed on startup: %s",
+            len(stale_runs),
+            [r.id for r in stale_runs],
+        )

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -269,25 +269,17 @@ async def _resolve_assets(client: ImmichClient, cfg: dict[str, Any]) -> list[Ass
     return assets
 
 
-async def _record_outcome(run_id: int, asset: Asset, result: dict[str, Any]) -> None:
-    async with AsyncSessionLocal() as db:
-        outcome = AssetOutcome(
-            run_id=run_id,
-            asset_id=asset.id,
-            filename=asset.original_file_name,
-            status=result["status"],
-            error=result.get("error"),
-            new_asset_id=result.get("new_asset_id"),
-            target_format=_get_target_format(asset),
-            input_bytes=result.get("input_bytes", 0),
-            output_bytes=result.get("output_bytes", 0),
-            updated_at=datetime.now(timezone.utc),
-        )
-        db.add(outcome)
-        await db.commit()
+async def _persist_asset_result(
+    run_id: int, asset: Asset, result: dict[str, Any]
+) -> dict[str, int]:
+    """Write the asset's outcome row and bump the run's counters/byte totals
+    in a single transaction, instead of three separate connections/commits.
+    Under fast, I/O-less skips this used to be the bottleneck: three SQLite
+    writers per asset competing for one file lock."""
+    status = result["status"]
+    input_bytes = result.get("input_bytes", 0)
+    output_bytes = result.get("output_bytes", 0)
 
-
-async def _bump_run_counters(run_id: int, status: str) -> dict[str, int]:
     increments: dict[str, Any] = {"processed_count": Run.processed_count + 1}
     if status in ("success", "partial_success", "dry_run_preview"):
         increments["success_count"] = Run.success_count + 1
@@ -295,34 +287,36 @@ async def _bump_run_counters(run_id: int, status: str) -> dict[str, int]:
         increments["skipped_count"] = Run.skipped_count + 1
     else:
         increments["failed_count"] = Run.failed_count + 1
+    if input_bytes or output_bytes:
+        increments["input_bytes"] = Run.input_bytes + input_bytes
+        increments["output_bytes"] = Run.output_bytes + output_bytes
 
     async with AsyncSessionLocal() as db:
+        outcome = AssetOutcome(
+            run_id=run_id,
+            asset_id=asset.id,
+            filename=asset.original_file_name,
+            status=status,
+            error=result.get("error"),
+            new_asset_id=result.get("new_asset_id"),
+            target_format=_get_target_format(asset),
+            input_bytes=input_bytes,
+            output_bytes=output_bytes,
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(outcome)
         await db.execute(update(Run).where(Run.id == run_id).values(**increments))
-        await db.commit()
-        result = await db.execute(select(Run).where(Run.id == run_id))
-        run = result.scalar_one()
-        return {
+        result_row = await db.execute(select(Run).where(Run.id == run_id))
+        run = result_row.scalar_one()
+        counters = {
             "processed_count": run.processed_count,
             "success_count": run.success_count,
             "skipped_count": run.skipped_count,
             "failed_count": run.failed_count,
             "total_assets": run.total_assets,
         }
-
-
-async def _add_run_bytes(run_id: int, input_bytes: int, output_bytes: int) -> None:
-    if not input_bytes and not output_bytes:
-        return
-    async with AsyncSessionLocal() as db:
-        await db.execute(
-            update(Run)
-            .where(Run.id == run_id)
-            .values(
-                input_bytes=Run.input_bytes + input_bytes,
-                output_bytes=Run.output_bytes + output_bytes,
-            )
-        )
         await db.commit()
+        return counters
 
 
 async def _run_one_asset(
@@ -347,15 +341,23 @@ async def _run_one_asset(
             }
         )
 
-        result = await asyncio.to_thread(
-            _process_asset_sync, asset, client, cfg, work_dir
-        )
+        try:
+            result = await asyncio.to_thread(
+                _process_asset_sync, asset, client, cfg, work_dir
+            )
+        except Exception as e:
+            # asyncio.gather() doesn't cancel sibling tasks when one of them
+            # raises -- letting this propagate would make execute_run's
+            # except/finally run work_dir cleanup while other assets are
+            # still mid-download into that same directory.
+            logger.exception("Unhandled error processing asset %s", asset.id)
+            result = {"status": "failed_error", "error": str(e)}
 
-        await _record_outcome(run_id, asset, result)
-        await _add_run_bytes(
-            run_id, result.get("input_bytes", 0), result.get("output_bytes", 0)
-        )
-        counters = await _bump_run_counters(run_id, result["status"])
+        try:
+            counters = await _persist_asset_result(run_id, asset, result)
+        except Exception:
+            logger.exception("Failed to persist outcome for asset %s", asset.id)
+            return
 
         await websocket_manager.broadcast(
             {

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -1,0 +1,57 @@
+"""Tests for startup reconciliation of interrupted runs."""
+
+import pytest
+from sqlalchemy import delete, select
+
+from app.database import AsyncSessionLocal, init_db
+from app.models.run import Run
+from app.services.lifecycle import reconcile_interrupted_runs
+
+
+async def _make_run(db, status: str) -> int:
+    run = Run(status=status)
+    db.add(run)
+    await db.commit()
+    await db.refresh(run)
+    return run.id
+
+
+@pytest.mark.asyncio
+class TestReconcileInterruptedRuns:
+    async def test_marks_queued_and_running_as_failed(self):
+        await init_db()
+        async with AsyncSessionLocal() as db:
+            await db.execute(delete(Run))
+            await db.commit()
+            queued_id = await _make_run(db, "queued")
+            running_id = await _make_run(db, "running")
+            completed_id = await _make_run(db, "completed")
+
+        await reconcile_interrupted_runs()
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(Run))
+            runs = {r.id: r for r in result.scalars().all()}
+
+        assert runs[queued_id].status == "failed"
+        assert runs[queued_id].error_message == "Interrupted by application restart"
+        assert runs[queued_id].completed_at is not None
+        assert runs[running_id].status == "failed"
+        assert runs[completed_id].status == "completed"
+        assert runs[completed_id].error_message is None
+
+    async def test_noop_when_nothing_stale(self):
+        await init_db()
+        async with AsyncSessionLocal() as db:
+            await db.execute(delete(Run))
+            await db.commit()
+            await _make_run(db, "completed")
+
+        await reconcile_interrupted_runs()
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(select(Run))
+            runs = result.scalars().all()
+
+        assert len(runs) == 1
+        assert runs[0].status == "completed"

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -538,3 +538,76 @@ class TestExecuteRun:
         assert refreshed.success_count == 2
         assert {o.asset_id for o in outcomes} == {"run-a1", "run-a2"}
         assert all(o.status == "success" for o in outcomes)
+
+    async def test_one_asset_exception_does_not_abort_run(self, tmp_path, monkeypatch):
+        """An unexpected error in one asset's pipeline must not blow up the
+        whole gather() -- it should be recorded as a failed outcome and let
+        the rest of the run continue instead of aborting to execute_run's
+        except/finally (which deletes work_dir out from under any sibling
+        assets still using it)."""
+        monkeypatch.setenv("TEMP_DIR", str(tmp_path))
+        await init_db()
+        async with AsyncSessionLocal() as db:
+            await db.execute(delete(AssetOutcome))
+            await db.commit()
+
+        a1 = _make_asset("boom-a1", file_name="one.jpg")
+        a2 = _make_asset("boom-a2", file_name="two.jpg")
+        client = FakeClient(search_pages={"IMAGE": [[a1, a2], []], "VIDEO": [[]]})
+        monkeypatch.setattr(run_service, "ImmichClient", FakeClientFactory(client))
+        monkeypatch.setattr(run_service, "validate_output", lambda path, fmt: True)
+
+        def flaky_transcode(inp, out, distance):
+            if "boom-a1" in inp:
+                raise RuntimeError("disk exploded")
+            return TranscodeResult(
+                success=True,
+                input_path=inp,
+                output_path=out,
+                input_bytes=1000,
+                output_bytes=500,
+                input_format="jpg",
+            )
+
+        monkeypatch.setattr(run_service, "transcode", flaky_transcode)
+
+        cfg = {
+            **BASE_CFG,
+            "immich_api_base": "https://example.com/api/",
+            "immich_api_key": "key",
+            "asset_ids": None,
+            "asset_types": "IMAGE",
+            "album_id": None,
+            "include_archived": False,
+            "include_deleted": False,
+            "taken_after": None,
+            "taken_before": None,
+            "original_filename": None,
+            "max_assets": None,
+            "concurrency": 1,
+        }
+
+        async with AsyncSessionLocal() as db:
+            run = Run(status="queued", config_snapshot=json.dumps(cfg))
+            db.add(run)
+            await db.commit()
+            await db.refresh(run)
+            run_id = run.id
+
+        await run_service.execute_run(run_id)
+
+        async with AsyncSessionLocal() as db:
+            run_result = await db.execute(select(Run).where(Run.id == run_id))
+            refreshed = run_result.scalar_one()
+            outcomes_result = await db.execute(
+                select(AssetOutcome).where(AssetOutcome.run_id == run_id)
+            )
+            outcomes = {o.asset_id: o for o in outcomes_result.scalars().all()}
+
+        assert refreshed.status == "completed"
+        assert refreshed.processed_count == 2
+        assert refreshed.failed_count == 1
+        assert refreshed.success_count == 1
+        assert outcomes["boom-a1"].status == "failed_error"
+        assert "disk exploded" in outcomes["boom-a1"].error
+        assert outcomes["boom-a2"].status == "success"

--- a/frontend/js/active-run.js
+++ b/frontend/js/active-run.js
@@ -9,6 +9,7 @@ class ActiveRun {
     this.run = null;
     this.log = []; // ordered per-asset entries, updated in place as they resolve
     this._logIndex = new Map(); // asset_id -> index into this.log
+    this._rowEls = new Map(); // asset_id -> rendered <tr>
     this._unsubscribe = null;
     this.onBack = null; // set by RunPanel: return to the config screen
   }
@@ -17,6 +18,7 @@ class ActiveRun {
     this.runId = runId;
     this.log = [];
     this._logIndex.clear();
+    this._rowEls.clear();
     this.run = await api.get(`/runs/${runId}`);
     this._renderShell();
     this._renderSummary();
@@ -31,8 +33,10 @@ class ActiveRun {
 
     if (msg.type === "asset_progress") {
       if (msg.stage === "processing") {
+        const entry = { asset_id: msg.asset_id, filename: msg.filename, status: "processing" };
         this._logIndex.set(msg.asset_id, this.log.length);
-        this.log.push({ asset_id: msg.asset_id, filename: msg.filename, status: "processing" });
+        this.log.push(entry);
+        this._appendRow(entry);
       } else {
         const entry = {
           asset_id: msg.asset_id,
@@ -44,10 +48,15 @@ class ActiveRun {
           output_bytes: msg.output_bytes,
         };
         const idx = this._logIndex.get(msg.asset_id);
-        if (idx !== undefined) this.log[idx] = entry;
-        else this.log.push(entry);
+        if (idx !== undefined) {
+          this.log[idx] = entry;
+          this._updateRow(entry);
+        } else {
+          this._logIndex.set(msg.asset_id, this.log.length);
+          this.log.push(entry);
+          this._appendRow(entry);
+        }
       }
-      this._renderLog();
     } else if (msg.type === "run_progress") {
       Object.assign(this.run, {
         processed_count: msg.processed_count,
@@ -121,32 +130,58 @@ class ActiveRun {
     if (backBtn) backBtn.addEventListener("click", () => this.onBack && this.onBack());
   }
 
+  // Log rows are patched in place instead of re-rendering the whole table
+  // on every message -- with fast, I/O-less skips, messages can arrive in a
+  // burst fast enough that rebuilding the entire (growing) log on each one
+  // freezes the tab.
   _renderLog() {
+    const body = this.root.querySelector("#run-log-body");
+    if (!body) return;
+    body.innerHTML = `<tr><td colspan="6" class="placeholder">Waiting for the first asset&hellip;</td></tr>`;
+  }
+
+  _rowCells(o) {
+    return `
+      <td>${o.filename}</td>
+      <td class="${statusTextClass(o.status)}">${prettyStatus(o.status)}</td>
+      <td>${o.target_format || ""}</td>
+      <td>${o.input_bytes ? `${fmtBytes(o.input_bytes)} &rarr; ${fmtBytes(o.output_bytes)}` : ""}</td>
+      <td>${savedLabel(o.input_bytes, o.output_bytes)}</td>
+      <td>${o.error || ""}</td>
+    `;
+  }
+
+  _appendRow(entry) {
     const scrollEl = this.root.querySelector("#run-log-scroll");
     const body = this.root.querySelector("#run-log-body");
     if (!body) return;
-
     const nearBottom = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 24;
 
-    if (this.log.length === 0) {
-      body.innerHTML = `<tr><td colspan="6" class="placeholder">Waiting for the first asset&hellip;</td></tr>`;
+    if (this._rowEls.size === 0) {
+      body.innerHTML = "";
+    }
+
+    const tr = document.createElement("tr");
+    tr.innerHTML = this._rowCells(entry);
+    body.appendChild(tr);
+    this._rowEls.set(entry.asset_id, tr);
+
+    if (nearBottom) {
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+    }
+  }
+
+  _updateRow(entry) {
+    const tr = this._rowEls.get(entry.asset_id);
+    if (!tr) {
+      this._appendRow(entry);
       return;
     }
 
-    body.innerHTML = this.log
-      .map(
-        (o) => `
-          <tr>
-            <td>${o.filename}</td>
-            <td class="${statusTextClass(o.status)}">${prettyStatus(o.status)}</td>
-            <td>${o.target_format || ""}</td>
-            <td>${o.input_bytes ? `${fmtBytes(o.input_bytes)} &rarr; ${fmtBytes(o.output_bytes)}` : ""}</td>
-            <td>${savedLabel(o.input_bytes, o.output_bytes)}</td>
-            <td>${o.error || ""}</td>
-          </tr>
-        `
-      )
-      .join("");
+    const scrollEl = this.root.querySelector("#run-log-scroll");
+    const nearBottom = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 24;
+
+    tr.innerHTML = this._rowCells(entry);
 
     if (nearBottom) {
       scrollEl.scrollTop = scrollEl.scrollHeight;

--- a/frontend/js/format-utils.js
+++ b/frontend/js/format-utils.js
@@ -12,6 +12,7 @@ const STATUS_LABELS = {
   failed_upload: "Failed: upload",
   failed_copy: "Failed: metadata copy",
   failed_verification: "Failed: verification",
+  failed_error: "Failed: unexpected error",
 };
 
 function prettyStatus(status) {


### PR DESCRIPTION
## What changed

Fixes the app freezing/going unresponsive during runs with many fast skips: the live log rebuilt its entire table on every progress message, and SQLite was taking three uncoordinated commits per asset with no WAL mode, serializing writers and blocking readers. Also hardens run execution against crashes: one asset's unexpected failure no longer aborts the whole run, and a run left mid-flight by a killed/crashed process is now reconciled instead of staying stuck "running" forever.

## Related issue

Fixes #

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes