### PR TITLE
fix: run stability, live progress, and metadata-copy fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,12 @@
 # the Settings page in the web UI to change any of this -- env vars are
 # only read to seed the database the very first time it's created.
 
-# Immich connection
-IMMICH_API_BASE=https://your-immich-instance.com/api
-IMMICH_API_KEY=your_api_key_here
+# Immich connection (e.g. IMMICH_API_BASE=https://immich.example.com/api)
+# Leave blank to configure from the Settings page instead -- a non-empty
+# placeholder here is treated as "configured" and the app will actually try
+# to connect to it.
+IMMICH_API_BASE=
+IMMICH_API_KEY=
 
 # Default filters
 ASSET_TYPES=IMAGE,VIDEO

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import shutil
+import time
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -35,6 +36,21 @@ from app.services.websocket_manager import websocket_manager
 logger = logging.getLogger(__name__)
 
 _cancelled_runs: set[int] = set()
+
+# Concurrent assets each persist their outcome in their own transaction; SQLite
+# serializes the writes, but that commit order isn't guaranteed to match the
+# order in which each asset's asyncio task resumes afterwards. Without this
+# lock, two assets finishing close together can broadcast run_progress out of
+# commit order, making the displayed counters briefly jump backwards.
+_progress_locks: dict[int, asyncio.Lock] = {}
+
+# run_progress carries the same aggregate counters on every asset -- sending
+# it once per asset is wasted work once a run is processing hundreds of
+# assets a second (fast skips have no I/O to pace them). Throttling it still
+# leaves the live per-asset log (asset_progress) untouched; the true final
+# counters are always attached to run_completed regardless of throttling.
+PROGRESS_BROADCAST_INTERVAL = 0.2
+_last_progress_broadcast: dict[int, float] = {}
 
 
 def request_cancel(run_id: int) -> None:
@@ -353,29 +369,36 @@ async def _run_one_asset(
             logger.exception("Unhandled error processing asset %s", asset.id)
             result = {"status": "failed_error", "error": str(e)}
 
-        try:
-            counters = await _persist_asset_result(run_id, asset, result)
-        except Exception:
-            logger.exception("Failed to persist outcome for asset %s", asset.id)
-            return
+        lock = _progress_locks.setdefault(run_id, asyncio.Lock())
+        async with lock:
+            try:
+                counters = await _persist_asset_result(run_id, asset, result)
+            except Exception:
+                logger.exception("Failed to persist outcome for asset %s", asset.id)
+                return
 
-        await websocket_manager.broadcast(
-            {
-                "type": "asset_progress",
-                "run_id": run_id,
-                "asset_id": asset.id,
-                "filename": asset.original_file_name,
-                "stage": "done",
-                "status": result["status"],
-                "error": result.get("error"),
-                "target_format": _get_target_format(asset),
-                "input_bytes": result.get("input_bytes", 0),
-                "output_bytes": result.get("output_bytes", 0),
-            }
-        )
-        await websocket_manager.broadcast(
-            {"type": "run_progress", "run_id": run_id, **counters}
-        )
+            await websocket_manager.broadcast(
+                {
+                    "type": "asset_progress",
+                    "run_id": run_id,
+                    "asset_id": asset.id,
+                    "filename": asset.original_file_name,
+                    "stage": "done",
+                    "status": result["status"],
+                    "error": result.get("error"),
+                    "target_format": _get_target_format(asset),
+                    "input_bytes": result.get("input_bytes", 0),
+                    "output_bytes": result.get("output_bytes", 0),
+                }
+            )
+
+            now = time.monotonic()
+            last_sent = _last_progress_broadcast.get(run_id, 0.0)
+            if now - last_sent >= PROGRESS_BROADCAST_INTERVAL:
+                _last_progress_broadcast[run_id] = now
+                await websocket_manager.broadcast(
+                    {"type": "run_progress", "run_id": run_id, **counters}
+                )
 
 
 async def execute_run(run_id: int) -> None:
@@ -433,13 +456,17 @@ async def execute_run(run_id: int) -> None:
         logger.exception("Run %s failed", run_id)
         error_message = str(e)
     finally:
+        # Read the cancellation flag before discarding it -- discard first
+        # would always read back False here, so a cancelled run could never
+        # actually end up with final_status == "cancelled".
+        was_cancelled = _is_cancelled(run_id)
         shutil.rmtree(work_dir, ignore_errors=True)
         _cancelled_runs.discard(run_id)
+        _progress_locks.pop(run_id, None)
+        _last_progress_broadcast.pop(run_id, None)
 
     final_status = (
-        "cancelled"
-        if _is_cancelled(run_id)
-        else ("failed" if error_message else "completed")
+        "cancelled" if was_cancelled else ("failed" if error_message else "completed")
     )
     async with AsyncSessionLocal() as db:
         await db.execute(
@@ -451,7 +478,16 @@ async def execute_run(run_id: int) -> None:
                 error_message=error_message,
             )
         )
+        result = await db.execute(select(Run).where(Run.id == run_id))
+        run = result.scalar_one()
+        counters = {
+            "processed_count": run.processed_count,
+            "success_count": run.success_count,
+            "skipped_count": run.skipped_count,
+            "failed_count": run.failed_count,
+            "total_assets": run.total_assets,
+        }
         await db.commit()
     await websocket_manager.broadcast(
-        {"type": "run_completed", "run_id": run_id, "status": final_status}
+        {"type": "run_completed", "run_id": run_id, "status": final_status, **counters}
     )

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -124,6 +124,10 @@ def _process_asset_sync(
             is_valid = validate_output(output_path, "jxl")
 
         if not tx.success:
+            # No output was produced, so input_bytes must not carry a
+            # before/after size comparison -- otherwise the UI reads
+            # "output_bytes stayed 0" as "100% saved by producing nothing".
+            result["input_bytes"] = 0
             if tx.error and tx.error.startswith("Already "):
                 result["status"] = "skipped"
                 return result
@@ -131,6 +135,7 @@ def _process_asset_sync(
             result["error"] = tx.error
             return result
         if not is_valid:
+            result["input_bytes"] = 0
             result["status"] = "failed_transcode"
             result["error"] = "Output validation failed"
             return result

--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -132,17 +132,24 @@ def validate_output(path: str, expected_format: str) -> bool:
 
 def copy_metadata(
     source_path: str, dest_path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS
-) -> bool:
+) -> tuple[bool, str | None]:
     """Copy EXIF/XMP metadata from source to dest using exiftool.
 
     Strips any existing metadata from the destination first so that malformed
     tags (e.g. bogus IFD0 dimensions or StripOffsets from camera JPEGs) are
     not carried over by cjxl or ImageMagick.
+
+    -m ignores exiftool's "minor errors", e.g. wrapping a bare JXL codestream
+    (ImageMagick's default JXL output) in an ISO BMFF container so it has
+    somewhere to hold the EXIF/XMP boxes being written -- exactly what we
+    want here, but exiftool refuses to do it unless told the restructuring
+    is acceptable.
     """
     try:
         subprocess.run(
             [
                 "exiftool",
+                "-m",
                 "-overwrite_original",
                 "-all=",
                 "-tagsFromFile",
@@ -153,12 +160,14 @@ def copy_metadata(
             check=True,
             timeout=timeouts.metadata,
         )
-        return True
+        return True, None
     except subprocess.TimeoutExpired:
-        logger.warning("exiftool timed out copying metadata from %s", source_path)
-        return False
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+        return False, f"exiftool timed out after {timeouts.metadata}s"
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode(errors="replace") if e.stderr else ""
+        return False, f"exiftool failed: {stderr}"
+    except FileNotFoundError:
+        return False, "exiftool not found"
 
 
 def _transcode_with_magick(
@@ -181,7 +190,10 @@ def _transcode_with_magick(
         ]
         try:
             subprocess.run(cmd, check=True, capture_output=True, timeout=timeouts.image)
-            if not copy_metadata(input_path, output_path, timeouts=timeouts):
+            metadata_ok, metadata_error = copy_metadata(
+                input_path, output_path, timeouts=timeouts
+            )
+            if not metadata_ok:
                 return TranscodeResult(
                     success=False,
                     input_path=input_path,
@@ -189,7 +201,7 @@ def _transcode_with_magick(
                     input_bytes=input_bytes,
                     output_bytes=0,
                     input_format=input_format or "unknown",
-                    error=f"Metadata copy failed for {input_path}",
+                    error=metadata_error or f"Metadata copy failed for {input_path}",
                 )
 
             output_bytes = (

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -611,3 +611,75 @@ class TestExecuteRun:
         assert outcomes["boom-a1"].status == "failed_error"
         assert "disk exploded" in outcomes["boom-a1"].error
         assert outcomes["boom-a2"].status == "success"
+
+    async def test_cancel_during_run_marks_run_cancelled(self, tmp_path, monkeypatch):
+        """A run cancelled while assets are still processing must end up
+        status == "cancelled" -- the flag used to be discarded before it was
+        read, so every cancelled run silently reported "completed" instead."""
+        monkeypatch.setenv("TEMP_DIR", str(tmp_path))
+        await init_db()
+        async with AsyncSessionLocal() as db:
+            await db.execute(delete(AssetOutcome))
+            await db.commit()
+
+        a1 = _make_asset("cancel-a1", file_name="one.jpg")
+        a2 = _make_asset("cancel-a2", file_name="two.jpg")
+        a3 = _make_asset("cancel-a3", file_name="three.jpg")
+        client = FakeClient(search_pages={"IMAGE": [[a1, a2, a3], []], "VIDEO": [[]]})
+        monkeypatch.setattr(run_service, "ImmichClient", FakeClientFactory(client))
+        monkeypatch.setattr(run_service, "validate_output", lambda path, fmt: True)
+
+        run_id_holder: dict[str, int] = {}
+
+        def cancel_on_first_asset(inp, out, distance):
+            if "cancel-a1" in inp:
+                run_service.request_cancel(run_id_holder["id"])
+            return TranscodeResult(
+                success=True,
+                input_path=inp,
+                output_path=out,
+                input_bytes=1000,
+                output_bytes=500,
+                input_format="jpg",
+            )
+
+        monkeypatch.setattr(run_service, "transcode", cancel_on_first_asset)
+
+        cfg = {
+            **BASE_CFG,
+            "immich_api_base": "https://example.com/api/",
+            "immich_api_key": "key",
+            "asset_ids": None,
+            "asset_types": "IMAGE",
+            "album_id": None,
+            "include_archived": False,
+            "include_deleted": False,
+            "taken_after": None,
+            "taken_before": None,
+            "original_filename": None,
+            "max_assets": None,
+            "concurrency": 1,
+        }
+
+        async with AsyncSessionLocal() as db:
+            run = Run(status="queued", config_snapshot=json.dumps(cfg))
+            db.add(run)
+            await db.commit()
+            await db.refresh(run)
+            run_id_holder["id"] = run.id
+
+        await run_service.execute_run(run_id_holder["id"])
+
+        async with AsyncSessionLocal() as db:
+            run_result = await db.execute(
+                select(Run).where(Run.id == run_id_holder["id"])
+            )
+            refreshed = run_result.scalar_one()
+            outcomes_result = await db.execute(
+                select(AssetOutcome).where(AssetOutcome.run_id == run_id_holder["id"])
+            )
+            outcomes = outcomes_result.scalars().all()
+
+        assert refreshed.status == "cancelled"
+        assert refreshed.processed_count == 1
+        assert {o.asset_id for o in outcomes} == {"cancel-a1"}

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -298,6 +298,7 @@ class TestProcessAssetSyncImages:
         )
         result = run_service._process_asset_sync(asset, client, BASE_CFG, str(tmp_path))
         assert result["status"] == "failed_transcode"
+        assert result["input_bytes"] == 0
 
     def test_cleans_up_temp_files(self, tmp_path, monkeypatch):
         asset = _make_asset()
@@ -368,6 +369,7 @@ class TestProcessAssetSyncVideos:
         cfg = {**BASE_CFG, "dry_run": True}
         result = run_service._process_asset_sync(asset, client, cfg, str(tmp_path))
         assert result["status"] == "skipped"
+        assert result["input_bytes"] == 0
 
     def test_video_happy_path(self, tmp_path, monkeypatch):
         asset = _make_asset(

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -366,7 +366,7 @@ class TestCopyMetadata:
 
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.return_value = FakeCompletedProcess(returncode=0)
-            assert copy_metadata(str(src), str(dst)) is True
+            assert copy_metadata(str(src), str(dst)) == (True, None)
 
     def test_returns_false_on_called_process_error(self, tmp_path):
         src = tmp_path / "src.jpg"
@@ -375,8 +375,12 @@ class TestCopyMetadata:
         dst.write_bytes(b"b")
 
         with patch("app.services.transcode.subprocess.run") as mock_run:
-            mock_run.side_effect = subprocess.CalledProcessError(1, "exiftool")
-            assert copy_metadata(str(src), str(dst)) is False
+            mock_run.side_effect = subprocess.CalledProcessError(
+                1, "exiftool", stderr=b"Error: Unknown file type"
+            )
+            ok, error = copy_metadata(str(src), str(dst))
+            assert ok is False
+            assert "Unknown file type" in error
 
     def test_returns_false_on_timeout(self, tmp_path):
         src = tmp_path / "src.jpg"
@@ -386,7 +390,9 @@ class TestCopyMetadata:
 
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired("exiftool", 120)
-            assert copy_metadata(str(src), str(dst)) is False
+            ok, error = copy_metadata(str(src), str(dst))
+            assert ok is False
+            assert "timed out" in error
 
     def test_returns_false_on_missing_binary(self, tmp_path):
         src = tmp_path / "src.jpg"
@@ -396,7 +402,9 @@ class TestCopyMetadata:
 
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = FileNotFoundError("exiftool not found")
-            assert copy_metadata(str(src), str(dst)) is False
+            ok, error = copy_metadata(str(src), str(dst))
+            assert ok is False
+            assert "not found" in error
 
     def test_custom_metadata_timeout(self, tmp_path):
         src = tmp_path / "src.jpg"

--- a/frontend/js/active-run.js
+++ b/frontend/js/active-run.js
@@ -1,7 +1,13 @@
 /** Live progress view for a single run: summary panel plus a scrolling
  * per-asset log, driven by WebSocket events. Each row starts as "processing"
  * and resolves in place once its outcome arrives, so concurrent workers each
- * get their own line instead of a single shared status. */
+ * get their own line instead of a single shared status.
+ *
+ * Row and summary updates are batched into one requestAnimationFrame flush
+ * instead of applied per message: a fast bulk-skip run can emit well over a
+ * thousand messages a second, and doing a DOM write (plus a scroll-position
+ * read, which forces a synchronous layout) on every single one is enough to
+ * lock up the tab. */
 class ActiveRun {
   constructor(root) {
     this.root = root;
@@ -10,6 +16,9 @@ class ActiveRun {
     this.log = []; // ordered per-asset entries, updated in place as they resolve
     this._logIndex = new Map(); // asset_id -> index into this.log
     this._rowEls = new Map(); // asset_id -> rendered <tr>
+    this._dirtyRows = new Set(); // asset_ids awaiting the next flush
+    this._summaryDirty = false;
+    this._flushHandle = null;
     this._unsubscribe = null;
     this.onBack = null; // set by RunPanel: return to the config screen
   }
@@ -19,6 +28,12 @@ class ActiveRun {
     this.log = [];
     this._logIndex.clear();
     this._rowEls.clear();
+    this._dirtyRows.clear();
+    this._summaryDirty = false;
+    if (this._flushHandle !== null) {
+      cancelAnimationFrame(this._flushHandle);
+      this._flushHandle = null;
+    }
     this.run = await api.get(`/runs/${runId}`);
     this._renderShell();
     this._renderSummary();
@@ -36,7 +51,6 @@ class ActiveRun {
         const entry = { asset_id: msg.asset_id, filename: msg.filename, status: "processing" };
         this._logIndex.set(msg.asset_id, this.log.length);
         this.log.push(entry);
-        this._appendRow(entry);
       } else {
         const entry = {
           asset_id: msg.asset_id,
@@ -50,28 +64,51 @@ class ActiveRun {
         const idx = this._logIndex.get(msg.asset_id);
         if (idx !== undefined) {
           this.log[idx] = entry;
-          this._updateRow(entry);
         } else {
           this._logIndex.set(msg.asset_id, this.log.length);
           this.log.push(entry);
-          this._appendRow(entry);
         }
       }
+      this._dirtyRows.add(msg.asset_id);
+      this._scheduleFlush();
     } else if (msg.type === "run_progress") {
-      Object.assign(this.run, {
-        processed_count: msg.processed_count,
-        success_count: msg.success_count,
-        skipped_count: msg.skipped_count,
-        failed_count: msg.failed_count,
-        total_assets: msg.total_assets,
-      });
-      this._renderSummary();
+      this._applyCounters(msg);
+      this._summaryDirty = true;
+      this._scheduleFlush();
     } else if (msg.type === "run_completed") {
+      this._applyCounters(msg);
       this.run.status = msg.status;
       this._renderSummary();
     } else if (msg.type === "run_started") {
       this.run.status = "running";
       this._renderSummary();
+    }
+  }
+
+  _applyCounters(msg) {
+    if (msg.processed_count === undefined) return;
+    Object.assign(this.run, {
+      processed_count: msg.processed_count,
+      success_count: msg.success_count,
+      skipped_count: msg.skipped_count,
+      failed_count: msg.failed_count,
+      total_assets: msg.total_assets,
+    });
+  }
+
+  _scheduleFlush() {
+    if (this._flushHandle !== null) return;
+    this._flushHandle = requestAnimationFrame(() => this._flush());
+  }
+
+  _flush() {
+    this._flushHandle = null;
+    if (this._summaryDirty) {
+      this._summaryDirty = false;
+      this._renderSummary();
+    }
+    if (this._dirtyRows.size > 0) {
+      this._flushRows();
     }
   }
 
@@ -130,10 +167,6 @@ class ActiveRun {
     if (backBtn) backBtn.addEventListener("click", () => this.onBack && this.onBack());
   }
 
-  // Log rows are patched in place instead of re-rendering the whole table
-  // on every message -- with fast, I/O-less skips, messages can arrive in a
-  // burst fast enough that rebuilding the entire (growing) log on each one
-  // freezes the tab.
   _renderLog() {
     const body = this.root.querySelector("#run-log-body");
     if (!body) return;
@@ -151,37 +184,41 @@ class ActiveRun {
     `;
   }
 
-  _appendRow(entry) {
+  // Applies every row queued since the last flush in one batch: a single
+  // scroll-position read/write and a single reflow, no matter how many
+  // messages arrived in between.
+  _flushRows() {
     const scrollEl = this.root.querySelector("#run-log-scroll");
     const body = this.root.querySelector("#run-log-body");
-    if (!body) return;
+    if (!body) {
+      this._dirtyRows.clear();
+      return;
+    }
+
     const nearBottom = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 24;
 
     if (this._rowEls.size === 0) {
       body.innerHTML = "";
     }
 
-    const tr = document.createElement("tr");
-    tr.innerHTML = this._rowCells(entry);
-    body.appendChild(tr);
-    this._rowEls.set(entry.asset_id, tr);
+    const fragment = document.createDocumentFragment();
+    for (const assetId of this._dirtyRows) {
+      const idx = this._logIndex.get(assetId);
+      if (idx === undefined) continue;
+      const entry = this.log[idx];
 
-    if (nearBottom) {
-      scrollEl.scrollTop = scrollEl.scrollHeight;
+      let tr = this._rowEls.get(assetId);
+      if (!tr) {
+        tr = document.createElement("tr");
+        this._rowEls.set(assetId, tr);
+        fragment.appendChild(tr);
+      }
+      tr.innerHTML = this._rowCells(entry);
     }
-  }
-
-  _updateRow(entry) {
-    const tr = this._rowEls.get(entry.asset_id);
-    if (!tr) {
-      this._appendRow(entry);
-      return;
+    if (fragment.childNodes.length > 0) {
+      body.appendChild(fragment);
     }
-
-    const scrollEl = this.root.querySelector("#run-log-scroll");
-    const nearBottom = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - 24;
-
-    tr.innerHTML = this._rowCells(entry);
+    this._dirtyRows.clear();
 
     if (nearBottom) {
       scrollEl.scrollTop = scrollEl.scrollHeight;

--- a/frontend/js/settings-panel.js
+++ b/frontend/js/settings-panel.js
@@ -63,11 +63,11 @@ class SettingsPanel {
 
       <section class="panel">
         <h2>Retry &amp; Safety</h2>
-        <label>Video max dimension (0=disabled)
-          <input id="set-video-max-dimension" type="number" min="0" value="${s.video_max_dimension}" />
+        <label>Video max dimension in pixels, short side (0=disabled)
+          <input id="set-video-max-dimension" type="number" min="0" placeholder="e.g. 1080" value="${s.video_max_dimension}" />
         </label>
-        <label>Video audio bitrate
-          <input id="set-video-audio-bitrate" type="text" value="${s.video_audio_bitrate}" />
+        <label>Video audio bitrate (ffmpeg format, e.g. 64k)
+          <input id="set-video-audio-bitrate" type="text" placeholder="e.g. 64k" value="${s.video_audio_bitrate}" />
         </label>
         <label><input id="set-enable-retry" type="checkbox" ${s.enable_retry ? "checked" : ""} /> Retry with more compression if output is larger</label>
         <label>Image distance on retry


### PR DESCRIPTION
## What changed

A batch of fixes found while stress-testing a large real library run:

- Live run log batches DOM updates into animation frames instead of applying every message immediately, which could lock up the tab during fast bulk-skip runs
- Cancelling a run now actually ends up with status "cancelled" (the flag was read after being cleared, so it always silently reported "completed")
- Progress counters can no longer be broadcast out of commit order, and the aggregate counter broadcast is throttled instead of sent once per asset
- exiftool metadata-copy failures now keep the real error instead of a generic message, and the JXL/ISO-BMFF container rewrap it needs is accepted instead of rejected
- Skipped and failed-transcode outcomes no longer show a false "100% saved" (no output was ever produced)
- Video max dimension and audio bitrate settings fields spell out the expected units/format
- `.env.example`'s Immich connection fields are blank instead of a placeholder that gets silently treated as "configured" after a database reset

## Related issue

Fixes #

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes