### PR TITLE
ci: pin ruff and mypy versions in the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install linting tools
-        run: pip install ruff mypy types-requests
+        run: pip install ruff==0.15.21 mypy==2.2.0 types-requests
 
       - name: Lint with ruff
         run: ruff check backend/


### PR DESCRIPTION
## Summary
- CI's lint job installed `ruff`/`mypy` unpinned, so any new upstream release could change default-enabled rules and break Lint on unrelated PRs. Pins both to the versions `pyproject.toml`'s dev extras already declare as the minimum, verified clean against the current tree.

## Test plan
- [x] `ruff check backend/` and `ruff format --check backend/` pass at the pinned version
- [x] `mypy backend/app --ignore-missing-imports --explicit-package-bases` passes at the pinned version