### PR TITLE
fix: clarify Immich URL needs /api suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ docker run -d \
   ghcr.io/fabianwimberger/immich-convert-originals:main
 
 # Open http://localhost:8000, set your Immich URL/API key on the
-# Settings page, and start browsing.
+# Settings page, and start browsing. The URL must include the /api
+# suffix, e.g. https://photos.example.com/api.
 ```
 
 ### Option 2: Docker Compose (Build Locally)
@@ -79,7 +80,8 @@ cd immich-convert-originals
 mkdir -p data
 
 docker compose up -d
-# Open http://localhost:8000, then set your Immich URL/API key on the Settings page
+# Open http://localhost:8000, then set your Immich URL/API key on the Settings
+# page. The URL must include the /api suffix, e.g. https://photos.example.com/api.
 ```
 
 ### Option 3: Local Development

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -61,6 +61,8 @@ async def test_connection(
     client = ImmichClient(api_base=api_base, api_key=api_key, retry_max=0)
     ok, error = await asyncio.to_thread(client.test_connection)
     if not ok:
+        if error and "404" in error and "/api" not in api_base.rstrip("/").lower():
+            error += " -- does the URL include the /api suffix, e.g. https://photos.example.com/api?"
         return TestConnectionResponse(ok=False, error=error)
 
     info = await asyncio.to_thread(client.server_info)

--- a/backend/tests/test_routes_settings.py
+++ b/backend/tests/test_routes_settings.py
@@ -121,6 +121,42 @@ class TestConnectionCheck:
         assert data["server_version"] == "3.0.3"
 
     @responses.activate
+    async def test_404_without_api_suffix_hints_at_missing_api_path(self, client):
+        responses.add(
+            responses.POST,
+            "https://immich.example.com/search/metadata",
+            status=404,
+        )
+        resp = await client.post(
+            "/api/settings/test-connection",
+            json={
+                "immich_api_base": "https://immich.example.com/",
+                "immich_api_key": "key",
+            },
+        )
+        data = resp.json()
+        assert data["ok"] is False
+        assert "/api" in data["error"]
+
+    @responses.activate
+    async def test_404_with_api_suffix_already_present_has_no_hint(self, client):
+        responses.add(
+            responses.POST,
+            "https://immich.example.com/api/search/metadata",
+            status=404,
+        )
+        resp = await client.post(
+            "/api/settings/test-connection",
+            json={
+                "immich_api_base": "https://immich.example.com/api/",
+                "immich_api_key": "key",
+            },
+        )
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["error"] == "Search failed: HTTP 404"
+
+    @responses.activate
     async def test_uses_saved_credentials_when_override_omitted(self, client):
         await client.put(
             "/api/settings",

--- a/frontend/js/settings-fields.js
+++ b/frontend/js/settings-fields.js
@@ -3,6 +3,12 @@
  * (see backend/app/models/schemas.py); these mirror them for display, they
  * don't re-implement them. */
 const SETTINGS_FIELDS = {
+  immich_api_base: {
+    description:
+      "Must include the /api suffix -- Immich's API lives under that path, and omitting it returns an unhelpful 404.",
+    default: "none",
+    example: "e.g. https://photos.example.com/api",
+  },
   asset_types: {
     description: "Which asset types a filtered run considers by default.",
     default: "Images + Videos",

--- a/frontend/js/settings-panel.js
+++ b/frontend/js/settings-panel.js
@@ -22,6 +22,7 @@ class SettingsPanel {
         <label>API Base URL
           <input id="set-api-base" type="text" value="${s.immich_api_base}" placeholder="https://photos.example.com/api" />
         </label>
+        ${fieldHint("immich_api_base")}
         <label>API Key
           <input id="set-api-key" type="password" placeholder="${s.immich_api_key_set ? "•••••••• (set)" : "not set"}" />
         </label>


### PR DESCRIPTION
## Summary
- README setup instructions and the Settings-panel URL field now call out that the Immich URL must include the `/api` suffix
- `test-connection` appends a hint when a 404 looks like a missing `/api` suffix, instead of a bare `HTTP 404`

Closes #88

## Test plan
- [x] `pytest backend/tests/test_routes_settings.py` (15 passed, incl. 2 new cases)
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] Verified the field hint renders and the settings API serves it