### PR TITLE
docs: note multi-arch docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ JPEG XL shrinks photos by 20-40% and AV1 shrinks videos by 30-50% with no visibl
 
 ### Option 1: Prebuilt Docker Image (Recommended)
 
+Multi-arch image (`linux/amd64`, `linux/arm64`) — Docker pulls the right one automatically.
+
 ```bash
 # Create a directory for your configuration
 mkdir immich-converter && cd immich-converter


### PR DESCRIPTION
Closes #95's underlying question — the image has been multi-arch (`linux/amd64`, `linux/arm64`) since the Docker Publish workflow was added, this just documents it.