### PR TITLE
feat: add configurable JPEG XL repack effort

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -23,6 +23,7 @@ class SettingsResponse(BaseModel):
     image_target_format: str
     image_distance: float
     image_distance_retry: float
+    image_jxl_effort: int
     image_quality_heic: int
     image_quality_heic_retry: int
     image_quality_avif: int
@@ -52,6 +53,7 @@ class SettingsResponse(BaseModel):
             image_target_format=settings.image_target_format,
             image_distance=settings.image_distance,
             image_distance_retry=settings.image_distance_retry,
+            image_jxl_effort=settings.image_jxl_effort,
             image_quality_heic=settings.image_quality_heic,
             image_quality_heic_retry=settings.image_quality_heic_retry,
             image_quality_avif=settings.image_quality_avif,
@@ -88,6 +90,7 @@ class SettingsUpdate(BaseModel):
     image_target_format: str | None = None
     image_distance: float | None = Field(default=None, ge=0, le=25)
     image_distance_retry: float | None = Field(default=None, ge=0, le=25)
+    image_jxl_effort: int | None = Field(default=None, ge=1, le=9)
     image_quality_heic: int | None = Field(default=None, ge=0, le=100)
     image_quality_heic_retry: int | None = Field(default=None, ge=0, le=100)
     image_quality_avif: int | None = Field(default=None, ge=0, le=100)
@@ -167,6 +170,7 @@ class RunCreate(BaseModel):
     image_target_format: str | None = None
     image_distance: float | None = Field(default=None, ge=0, le=25)
     image_distance_retry: float | None = Field(default=None, ge=0, le=25)
+    image_jxl_effort: int | None = Field(default=None, ge=1, le=9)
     image_quality_heic: int | None = Field(default=None, ge=0, le=100)
     image_quality_heic_retry: int | None = Field(default=None, ge=0, le=100)
     image_quality_avif: int | None = Field(default=None, ge=0, le=100)

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -37,6 +37,9 @@ class Settings(Base):
     image_target_format: Mapped[str] = mapped_column(default="jxl")
     image_distance: Mapped[float] = mapped_column(default=1.0)
     image_distance_retry: Mapped[float] = mapped_column(default=2.0)
+    # cjxl --effort (1-9, higher=slower/smaller) for the JPEG->JXL lossless
+    # repack path only; ImageMagick's JXL encode doesn't go through cjxl.
+    image_jxl_effort: Mapped[int] = mapped_column(default=7)
     image_quality_heic: Mapped[int] = mapped_column(default=80)
     image_quality_heic_retry: Mapped[int] = mapped_column(default=60)
     image_quality_avif: Mapped[int] = mapped_column(default=75)

--- a/backend/app/routes/runs.py
+++ b/backend/app/routes/runs.py
@@ -62,6 +62,7 @@ async def _build_config_snapshot(data: RunCreate, db: AsyncSession) -> dict[str,
         "image_distance_retry": _pick(
             data.image_distance_retry, settings.image_distance_retry
         ),
+        "image_jxl_effort": _pick(data.image_jxl_effort, settings.image_jxl_effort),
         "image_quality_heic": _pick(
             data.image_quality_heic, settings.image_quality_heic
         ),

--- a/backend/app/services/run_service.py
+++ b/backend/app/services/run_service.py
@@ -232,6 +232,7 @@ def _process_asset_sync(
                 output_path,
                 target_format,
                 _get_image_quality(cfg, target_format, retry=False),
+                jxl_effort=cfg.get("image_jxl_effort", 7),
             )
             is_valid = validate_output(output_path, target_format)
 
@@ -275,6 +276,7 @@ def _process_asset_sync(
                         output_path,
                         target_format,
                         _get_image_quality(cfg, target_format, retry=True),
+                        jxl_effort=cfg.get("image_jxl_effort", 7),
                     )
                     is_valid = validate_output(output_path, target_format)
 

--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -262,6 +262,7 @@ def transcode(
     output_path: str,
     target_format: str,
     quality: float,
+    jxl_effort: int = 7,
     timeouts: Timeouts = DEFAULT_TIMEOUTS,
 ) -> TranscodeResult:
     """Transcode an image to the given target format.
@@ -272,6 +273,10 @@ def transcode(
     those falls through to the normal ImageMagick re-encode below.
     Everything else: ImageMagick with the given quality (JXL distance 0-25,
     or HEIC/AVIF -quality 0-100).
+
+    jxl_effort (1-9) only applies to the cjxl repack above -- it trades
+    encode time for smaller output via cjxl's entropy coding, independent of
+    the lossless bit-exactness of the repack itself.
     """
     input_bytes = os.path.getsize(input_path)
     input_format = detect_format(input_path)
@@ -306,7 +311,13 @@ def transcode(
         # is unnecessary and can accidentally downgrade metadata.
         try:
             result = subprocess.run(
-                ["cjxl", "--compress_boxes=0", input_path, output_path],
+                [
+                    "cjxl",
+                    "--compress_boxes=0",
+                    f"--effort={jxl_effort}",
+                    input_path,
+                    output_path,
+                ],
                 capture_output=True,
                 timeout=timeouts.image,
             )

--- a/backend/tests/test_routes_runs.py
+++ b/backend/tests/test_routes_runs.py
@@ -89,6 +89,21 @@ class TestCreateRun:
             # Unset overrides fall back to the saved Settings defaults.
             assert cfg["image_quality_avif"] == 75
 
+    async def test_image_jxl_effort_override_stored_in_snapshot(self, client):
+        await _configure_connection(client)
+        resp = await client.post(
+            "/api/runs",
+            json={"asset_types": "IMAGE", "image_jxl_effort": 9},
+        )
+        data = resp.json()
+        async with AsyncSessionLocal() as db:
+            from sqlalchemy import select
+
+            result = await db.execute(select(Run).where(Run.id == data["id"]))
+            run = result.scalar_one()
+            cfg = json.loads(run.config_snapshot)
+            assert cfg["image_jxl_effort"] == 9
+
     async def test_output_mode_override_stored_in_snapshot(self, client):
         await _configure_connection(client)
         resp = await client.post(

--- a/backend/tests/test_routes_settings.py
+++ b/backend/tests/test_routes_settings.py
@@ -21,6 +21,7 @@ class TestReadSettings:
         assert data["concurrency"] == 2
         assert data["convert_image_formats"] == "jpg,png,webp,heic,avif,tiff,gif,bmp"
         assert data["image_target_format"] == "jxl"
+        assert data["image_jxl_effort"] == 7
         assert data["image_quality_heic"] == 80
         assert data["image_quality_avif"] == 75
         assert data["output_mode"] == "upload"
@@ -72,6 +73,14 @@ class TestUpdateSettings:
 
     async def test_out_of_range_image_quality_rejected(self, client):
         resp = await client.put("/api/settings", json={"image_quality_heic": 150})
+        assert resp.status_code == 422
+
+    async def test_image_jxl_effort_persists(self, client):
+        resp = await client.put("/api/settings", json={"image_jxl_effort": 3})
+        assert resp.json()["image_jxl_effort"] == 3
+
+    async def test_out_of_range_image_jxl_effort_rejected(self, client):
+        resp = await client.put("/api/settings", json={"image_jxl_effort": 10})
         assert resp.status_code == 422
 
     async def test_output_mode_and_local_dir_persist(self, client):

--- a/backend/tests/test_run_service.py
+++ b/backend/tests/test_run_service.py
@@ -181,7 +181,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -201,7 +201,7 @@ class TestProcessAssetSyncImages:
         cfg = {**BASE_CFG, "image_target_format": "avif", "dry_run": True}
         captured = {}
 
-        def fake_transcode(inp, out, fmt, quality):
+        def fake_transcode(inp, out, fmt, quality, jxl_effort=7):
             captured["fmt"] = fmt
             captured["quality"] = quality
             captured["out"] = out
@@ -224,6 +224,57 @@ class TestProcessAssetSyncImages:
         assert captured["quality"] == BASE_CFG["image_quality_avif"]
         assert captured["out"].endswith(".avif")
 
+    def test_uses_configured_jxl_effort(self, tmp_path, monkeypatch):
+        asset = _make_asset()
+        client = FakeClient()
+        cfg = {**BASE_CFG, "image_jxl_effort": 9, "dry_run": True}
+        captured = {}
+
+        def fake_transcode(inp, out, fmt, quality, jxl_effort=7):
+            captured["jxl_effort"] = jxl_effort
+            return TranscodeResult(
+                success=True,
+                input_path=inp,
+                output_path=out,
+                input_bytes=1000,
+                output_bytes=500,
+                input_format="jpg",
+            )
+
+        monkeypatch.setattr(run_service, "transcode", fake_transcode)
+        monkeypatch.setattr(run_service, "validate_output", lambda path, fmt: True)
+
+        run_service._process_asset_sync(asset, client, cfg, str(tmp_path))
+        assert captured["jxl_effort"] == 9
+
+    def test_missing_jxl_effort_key_defaults_to_7(self, tmp_path, monkeypatch):
+        """A config_snapshot persisted before this setting existed (e.g. a
+        retry-failed run started from an old run row) has no
+        image_jxl_effort key at all -- it must still fall back to 7 instead
+        of KeyError-ing."""
+        asset = _make_asset()
+        client = FakeClient()
+        cfg = {k: v for k, v in BASE_CFG.items() if k != "image_jxl_effort"}
+        cfg["dry_run"] = True
+        captured = {}
+
+        def fake_transcode(inp, out, fmt, quality, jxl_effort=7):
+            captured["jxl_effort"] = jxl_effort
+            return TranscodeResult(
+                success=True,
+                input_path=inp,
+                output_path=out,
+                input_bytes=1000,
+                output_bytes=500,
+                input_format="jpg",
+            )
+
+        monkeypatch.setattr(run_service, "transcode", fake_transcode)
+        monkeypatch.setattr(run_service, "validate_output", lambda path, fmt: True)
+
+        run_service._process_asset_sync(asset, client, cfg, str(tmp_path))
+        assert captured["jxl_effort"] == 7
+
     def test_missing_convert_image_formats_key_defaults_to_all(self, tmp_path):
         """A config_snapshot persisted before this setting existed (e.g. a
         retry-failed run started from an old run row) has no
@@ -245,7 +296,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -276,7 +327,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -297,7 +348,7 @@ class TestProcessAssetSyncImages:
         client = FakeClient()
         calls = []
 
-        def fake_transcode(inp, out, fmt, distance):
+        def fake_transcode(inp, out, fmt, distance, jxl_effort=7):
             calls.append(distance)
             output = 1500 if len(calls) == 1 else 400
             return TranscodeResult(
@@ -322,7 +373,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -342,7 +393,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -362,7 +413,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -383,7 +434,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -404,7 +455,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -424,7 +475,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=False,
                 input_path=inp,
                 output_path=out,
@@ -444,7 +495,7 @@ class TestProcessAssetSyncImages:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -460,7 +511,7 @@ class TestProcessAssetSyncImages:
 
 class TestProcessAssetSyncLocalMode:
     def _patch_transcode(self, monkeypatch, input_format="jpg"):
-        def fake_transcode(inp, out, fmt, quality):
+        def fake_transcode(inp, out, fmt, quality, jxl_effort=7):
             # shutil.move/copy2 in the local-save path need a real file --
             # unlike upload_asset (which just reads kwargs), this is the
             # first path that actually touches output_path on disk.
@@ -756,7 +807,7 @@ class TestExecuteRun:
         monkeypatch.setattr(
             run_service,
             "transcode",
-            lambda inp, out, fmt, distance: TranscodeResult(
+            lambda inp, out, fmt, distance, jxl_effort=7: TranscodeResult(
                 success=True,
                 input_path=inp,
                 output_path=out,
@@ -825,7 +876,7 @@ class TestExecuteRun:
         monkeypatch.setattr(run_service, "ImmichClient", FakeClientFactory(client))
         monkeypatch.setattr(run_service, "validate_output", lambda path, fmt: True)
 
-        def flaky_transcode(inp, out, fmt, distance):
+        def flaky_transcode(inp, out, fmt, distance, jxl_effort=7):
             if "boom-a1" in inp:
                 raise RuntimeError("disk exploded")
             return TranscodeResult(
@@ -899,7 +950,7 @@ class TestExecuteRun:
 
         run_id_holder: dict[str, int] = {}
 
-        def cancel_on_first_asset(inp, out, fmt, distance):
+        def cancel_on_first_asset(inp, out, fmt, distance, jxl_effort=7):
             if "cancel-a1" in inp:
                 run_service.request_cancel(run_id_holder["id"])
             return TranscodeResult(

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -36,6 +36,28 @@ class TestTranscodeImage:
         assert mock_run.call_count == 1
         assert mock_run.call_args_list[0][0][0][0] == "cjxl"
 
+    def test_jpeg_cjxl_defaults_to_effort_7(self, tmp_path):
+        input_path = tmp_path / "input.jpg"
+        input_path.write_bytes(b"\xff\xd8\xff" + b"\x00" * 29)
+        output_path = tmp_path / "output.jxl"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(returncode=0)
+            transcode(str(input_path), str(output_path), "jxl", 1.0)
+
+        assert "--effort=7" in mock_run.call_args_list[0][0][0]
+
+    def test_jpeg_cjxl_uses_configured_effort(self, tmp_path):
+        input_path = tmp_path / "input.jpg"
+        input_path.write_bytes(b"\xff\xd8\xff" + b"\x00" * 29)
+        output_path = tmp_path / "output.jxl"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(returncode=0)
+            transcode(str(input_path), str(output_path), "jxl", 1.0, jxl_effort=3)
+
+        assert "--effort=3" in mock_run.call_args_list[0][0][0]
+
     def test_jpeg_cjxl_not_found_falls_back_to_magick(self, tmp_path):
         input_path = tmp_path / "input.jpg"
         input_path.write_bytes(b"\xff\xd8\xff" + b"\x00" * 29)

--- a/frontend/js/settings-fields.js
+++ b/frontend/js/settings-fields.js
@@ -41,6 +41,12 @@ const SETTINGS_FIELDS = {
     description: "Distance used if the first pass came out larger than the original.",
     default: "2.0",
   },
+  image_jxl_effort: {
+    description:
+      "cjxl --effort for the JPEG->JXL lossless repack -- higher is slower but smaller. Only applies to JPEG sources targeting JXL; ImageMagick's re-encode path ignores it.",
+    default: "7",
+    example: "e.g. 9 for maximum compression, 3 for faster batch runs",
+  },
   image_quality_heic: {
     description: "HEIC quality (ImageMagick -quality) -- higher is better and larger.",
     default: "80",

--- a/frontend/js/settings-panel.js
+++ b/frontend/js/settings-panel.js
@@ -77,6 +77,10 @@ class SettingsPanel {
             <input id="set-image-distance-retry" type="number" step="0.1" min="0" max="25" value="${s.image_distance_retry}" />
             ${fieldHint("image_distance_retry")}
           </label>
+          <label>JPEG repack effort (1-9)
+            <input id="set-image-jxl-effort" type="number" step="1" min="1" max="9" value="${s.image_jxl_effort}" />
+            ${fieldHint("image_jxl_effort")}
+          </label>
         </div>
         <div class="format-fields" data-format="heic" style="${s.image_target_format === "heic" ? "" : "display:none"}">
           <label>Quality (0-100)
@@ -266,6 +270,10 @@ class SettingsPanel {
       image_distance: parseFloat(this.root.querySelector("#set-image-distance").value),
       image_distance_retry: parseFloat(
         this.root.querySelector("#set-image-distance-retry").value
+      ),
+      image_jxl_effort: parseInt(
+        this.root.querySelector("#set-image-jxl-effort").value,
+        10
       ),
       image_quality_heic: parseInt(
         this.root.querySelector("#set-image-quality-heic").value,


### PR DESCRIPTION
Closes #98.

Adds a Settings-page and per-run `image_jxl_effort` (1-9, default 7) knob, wired through to the `cjxl --effort` flag used by the JPEG->JXL lossless repack path. The ImageMagick re-encode path (HEIC/AVIF targets, non-JPEG sources) is unaffected.