### PR TITLE
feat: apply JXL effort to all targets, bump range to 1-10

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -90,7 +90,7 @@ class SettingsUpdate(BaseModel):
     image_target_format: str | None = None
     image_distance: float | None = Field(default=None, ge=0, le=25)
     image_distance_retry: float | None = Field(default=None, ge=0, le=25)
-    image_jxl_effort: int | None = Field(default=None, ge=1, le=9)
+    image_jxl_effort: int | None = Field(default=None, ge=1, le=10)
     image_quality_heic: int | None = Field(default=None, ge=0, le=100)
     image_quality_heic_retry: int | None = Field(default=None, ge=0, le=100)
     image_quality_avif: int | None = Field(default=None, ge=0, le=100)
@@ -170,7 +170,7 @@ class RunCreate(BaseModel):
     image_target_format: str | None = None
     image_distance: float | None = Field(default=None, ge=0, le=25)
     image_distance_retry: float | None = Field(default=None, ge=0, le=25)
-    image_jxl_effort: int | None = Field(default=None, ge=1, le=9)
+    image_jxl_effort: int | None = Field(default=None, ge=1, le=10)
     image_quality_heic: int | None = Field(default=None, ge=0, le=100)
     image_quality_heic_retry: int | None = Field(default=None, ge=0, le=100)
     image_quality_avif: int | None = Field(default=None, ge=0, le=100)

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -37,8 +37,8 @@ class Settings(Base):
     image_target_format: Mapped[str] = mapped_column(default="jxl")
     image_distance: Mapped[float] = mapped_column(default=1.0)
     image_distance_retry: Mapped[float] = mapped_column(default=2.0)
-    # cjxl --effort (1-9, higher=slower/smaller) for the JPEG->JXL lossless
-    # repack path only; ImageMagick's JXL encode doesn't go through cjxl.
+    # JXL encoder effort (1-10, higher=slower/smaller): cjxl --effort for the
+    # JPEG->JXL lossless repack, jxl:effort define for ImageMagick otherwise.
     image_jxl_effort: Mapped[int] = mapped_column(default=7)
     image_quality_heic: Mapped[int] = mapped_column(default=80)
     image_quality_heic_retry: Mapped[int] = mapped_column(default=60)

--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -175,6 +175,7 @@ def _transcode_with_magick(
     output_path: str,
     target_format: str,
     quality: float,
+    jxl_effort: int = 7,
     timeouts: Timeouts = DEFAULT_TIMEOUTS,
 ) -> TranscodeResult:
     """Transcode using ImageMagick.
@@ -182,13 +183,20 @@ def _transcode_with_magick(
     `quality` is JXL distance (0-25) when target_format == "jxl", otherwise
     a 0-100 ImageMagick -quality value (HEIC/AVIF). Output container is
     whatever output_path's extension is -- ImageMagick picks the delegate
-    from it, same as it always has.
+    from it, same as it always has. `jxl_effort` is passed through to
+    libjxl's encoder via ImageMagick's jxl:effort define for any JXL target,
+    not just the cjxl lossless repack.
     """
     input_bytes = os.path.getsize(input_path)
     input_format = detect_format(input_path)
 
     quality_args = (
-        ["-define", f"jxl:distance={quality}"]
+        [
+            "-define",
+            f"jxl:distance={quality}",
+            "-define",
+            f"jxl:effort={jxl_effort}",
+        ]
         if target_format == "jxl"
         else ["-quality", str(quality)]
     )
@@ -274,9 +282,10 @@ def transcode(
     Everything else: ImageMagick with the given quality (JXL distance 0-25,
     or HEIC/AVIF -quality 0-100).
 
-    jxl_effort (1-9) only applies to the cjxl repack above -- it trades
-    encode time for smaller output via cjxl's entropy coding, independent of
-    the lossless bit-exactness of the repack itself.
+    jxl_effort (1-10) applies to every JXL target, via cjxl's --effort above
+    or ImageMagick's jxl:effort define otherwise. It trades encode time for
+    smaller output, independent of quality/distance or the lossless
+    bit-exactness of the cjxl repack. Ignored for non-JXL targets.
     """
     input_bytes = os.path.getsize(input_path)
     input_format = detect_format(input_path)
@@ -334,7 +343,12 @@ def transcode(
         except FileNotFoundError:
             # cjxl not installed - fall back to ImageMagick
             return _transcode_with_magick(
-                input_path, output_path, target_format, quality, timeouts=timeouts
+                input_path,
+                output_path,
+                target_format,
+                quality,
+                jxl_effort=jxl_effort,
+                timeouts=timeouts,
             )
 
         if result.returncode == 0:
@@ -352,11 +366,21 @@ def transcode(
         else:
             # cjxl failed (e.g., progressive JPEG) - fall back to ImageMagick
             return _transcode_with_magick(
-                input_path, output_path, target_format, quality, timeouts=timeouts
+                input_path,
+                output_path,
+                target_format,
+                quality,
+                jxl_effort=jxl_effort,
+                timeouts=timeouts,
             )
     else:
         return _transcode_with_magick(
-            input_path, output_path, target_format, quality, timeouts=timeouts
+            input_path,
+            output_path,
+            target_format,
+            quality,
+            jxl_effort=jxl_effort,
+            timeouts=timeouts,
         )
 
 

--- a/backend/tests/test_routes_settings.py
+++ b/backend/tests/test_routes_settings.py
@@ -79,8 +79,12 @@ class TestUpdateSettings:
         resp = await client.put("/api/settings", json={"image_jxl_effort": 3})
         assert resp.json()["image_jxl_effort"] == 3
 
-    async def test_out_of_range_image_jxl_effort_rejected(self, client):
+    async def test_image_jxl_effort_accepts_ten(self, client):
         resp = await client.put("/api/settings", json={"image_jxl_effort": 10})
+        assert resp.json()["image_jxl_effort"] == 10
+
+    async def test_out_of_range_image_jxl_effort_rejected(self, client):
+        resp = await client.put("/api/settings", json={"image_jxl_effort": 11})
         assert resp.status_code == 422
 
     async def test_output_mode_and_local_dir_persist(self, client):

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -108,6 +108,20 @@ class TestTranscodeImage:
         assert mock_run.call_count >= 1
         assert mock_run.call_args_list[0][0][0][0] == "magick"
 
+    def test_non_jpeg_to_jxl_uses_configured_effort(self, tmp_path):
+        input_path = tmp_path / "input.png"
+        input_path.write_bytes(b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" + b"\x00" * 24)
+        output_path = tmp_path / "output.jxl"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(returncode=0)
+            transcode(str(input_path), str(output_path), "jxl", 1.0, jxl_effort=9)
+
+        args = mock_run.call_args_list[0][0][0]
+        assert "-define" in args
+        assert "jxl:effort=9" in args
+        assert "jxl:distance=1.0" in args
+
     def test_refuses_jxl_input(self, tmp_path):
         input_path = tmp_path / "input.jxl"
         input_path.write_bytes(b"\xff\x0a" + b"\x00" * 30)

--- a/frontend/js/settings-fields.js
+++ b/frontend/js/settings-fields.js
@@ -43,9 +43,9 @@ const SETTINGS_FIELDS = {
   },
   image_jxl_effort: {
     description:
-      "cjxl --effort for the JPEG->JXL lossless repack -- higher is slower but smaller. Only applies to JPEG sources targeting JXL; ImageMagick's re-encode path ignores it.",
+      "Encoder effort for any JXL target -- higher is slower but smaller. Applies to JPEG sources via cjxl's lossless repack, and to all other sources via ImageMagick's JXL encoder.",
     default: "7",
-    example: "e.g. 9 for maximum compression, 3 for faster batch runs",
+    example: "e.g. 10 for maximum compression, 3 for faster batch runs",
   },
   image_quality_heic: {
     description: "HEIC quality (ImageMagick -quality) -- higher is better and larger.",

--- a/frontend/js/settings-panel.js
+++ b/frontend/js/settings-panel.js
@@ -77,8 +77,8 @@ class SettingsPanel {
             <input id="set-image-distance-retry" type="number" step="0.1" min="0" max="25" value="${s.image_distance_retry}" />
             ${fieldHint("image_distance_retry")}
           </label>
-          <label>JPEG repack effort (1-9)
-            <input id="set-image-jxl-effort" type="number" step="1" min="1" max="9" value="${s.image_jxl_effort}" />
+          <label>JXL encoder effort (1-10)
+            <input id="set-image-jxl-effort" type="number" step="1" min="1" max="10" value="${s.image_jxl_effort}" />
             ${fieldHint("image_jxl_effort")}
           </label>
         </div>


### PR DESCRIPTION
## What changed

Addresses the follow-up on #98: `--effort` only ever reached cjxl's lossless JPEG→JXL repack. Every other source targeting JXL (PNG, HEIC, etc.) went through ImageMagick's encoder with no effort control at all. `jxl_effort` is now wired into ImageMagick's `jxl:effort` define for that path too, so it applies uniformly to any JXL target.

Also bumps the accepted range from 1-9 to 1-10 to match libjxl 0.11.x.

## Related issue

Fixes #98

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally (pytest 220 passed, ruff check/format clean, mypy clean)
- [x] CI passes