### PR TITLE
develop: TIFF conversion fix and HDR video support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONUNBUFFERED=1
 
 RUN apk add --no-cache \
     libjxl-tools \
-    imagemagick imagemagick-heic imagemagick-jxl imagemagick-webp \
+    imagemagick imagemagick-heic imagemagick-jxl imagemagick-webp imagemagick-tiff \
     exiftool \
     ffmpeg
 

--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -121,6 +121,50 @@ def detect_video_codec(path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS) -> str 
         return None
 
 
+# ffprobe color_transfer value -> SVT-AV1 transfer-characteristics code.
+# Anything not in this map (including untagged/SDR streams) is treated as SDR.
+HDR_TRANSFER_CHARACTERISTICS = {
+    "smpte2084": "16",  # PQ (HDR10 / HDR10+)
+    "arib-std-b67": "18",  # HLG
+}
+
+
+def detect_hdr_transfer(path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS) -> str | None:
+    """Detect HDR transfer characteristic using ffprobe.
+
+    Returns the ffprobe color_transfer value ("smpte2084" or "arib-std-b67")
+    when the stream is tagged HDR, otherwise None -- covers SDR and untagged
+    sources the same way.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=color_transfer",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeouts.probe,
+        )
+        if result.returncode == 0:
+            transfer = result.stdout.strip().lower()
+            return transfer if transfer in HDR_TRANSFER_CHARACTERISTICS else None
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("ffprobe timed out detecting HDR transfer for %s", path)
+        return None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
 def validate_output(path: str, expected_format: str) -> bool:
     """Validate output file exists, is non-zero, and has correct magic bytes."""
     if not os.path.exists(path):
@@ -395,6 +439,11 @@ def transcode_video(
 ) -> TranscodeResult:
     """Transcode a video to MP4/AV1 using ffmpeg + SVT-AV1.
 
+    HDR10/HDR10+ (PQ) and HLG sources are detected via ffprobe's
+    color_transfer tag and re-encoded 10-bit with BT.2020 primaries and
+    matching transfer characteristics carried through to the AV1 stream,
+    instead of being flattened to 8-bit SDR. Everything else is unaffected.
+
     Args:
         crf: Quality (0-63, lower=better)
         preset: Speed preset (0-13, lower=slower/better)
@@ -429,6 +478,8 @@ def transcode_video(
             error="Already AV1",
         )
 
+    hdr_transfer = detect_hdr_transfer(input_path, timeouts=timeouts)
+
     cmd = [
         "ffmpeg",
         "-y",
@@ -451,10 +502,33 @@ def transcode_video(
         )
         cmd.extend(["-vf", scale_filter])
 
+    if hdr_transfer:
+        svtav1_params = [
+            "enable-hdr=1",
+            "color-primaries=9",  # BT.2020
+            f"transfer-characteristics={HDR_TRANSFER_CHARACTERISTICS[hdr_transfer]}",
+            "matrix-coefficients=9",  # BT.2020 non-constant luminance
+            "color-range=0",  # Limited/TV range
+        ]
+        cmd.extend(
+            [
+                "-pix_fmt",
+                "yuv420p10le",
+                "-color_primaries",
+                "bt2020",
+                "-color_trc",
+                hdr_transfer,
+                "-colorspace",
+                "bt2020nc",
+                "-svtav1-params",
+                ":".join(svtav1_params),
+            ]
+        )
+    else:
+        cmd.extend(["-pix_fmt", "yuv420p"])
+
     cmd.extend(
         [
-            "-pix_fmt",
-            "yuv420p",
             "-c:a",
             "libopus",
             "-b:a",

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -7,6 +7,7 @@ import subprocess
 from app.services.transcode import (
     Timeouts,
     copy_metadata,
+    detect_hdr_transfer,
     detect_video_codec,
     transcode,
     transcode_video,
@@ -358,6 +359,7 @@ class TestTranscodeVideo:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
                 FileNotFoundError("ffmpeg not found"),
             ]
             result = transcode_video(
@@ -375,6 +377,7 @@ class TestTranscodeVideo:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
                 subprocess.TimeoutExpired("ffmpeg", 43200),
             ]
             result = transcode_video(
@@ -393,6 +396,7 @@ class TestTranscodeVideo:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
                 FakeCompletedProcess(returncode=0),
             ]
             transcode_video(
@@ -405,10 +409,79 @@ class TestTranscodeVideo:
                 timeouts=timeouts,
             )
 
-        probe_call = mock_run.call_args_list[0]
-        video_call = mock_run.call_args_list[1]
-        assert probe_call[1]["timeout"] == 11
+        codec_probe_call = mock_run.call_args_list[0]
+        hdr_probe_call = mock_run.call_args_list[1]
+        video_call = mock_run.call_args_list[2]
+        assert codec_probe_call[1]["timeout"] == 11
+        assert hdr_probe_call[1]["timeout"] == 11
         assert video_call[1]["timeout"] == 99
+
+    def test_hdr_pq_uses_10bit_and_bt2020(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="hevc"),
+                FakeCompletedProcess(stdout="smpte2084"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert args[args.index("-pix_fmt") + 1] == "yuv420p10le"
+        assert args[args.index("-color_primaries") + 1] == "bt2020"
+        assert args[args.index("-color_trc") + 1] == "smpte2084"
+        assert args[args.index("-colorspace") + 1] == "bt2020nc"
+        svtav1_params = args[args.index("-svtav1-params") + 1]
+        assert "enable-hdr=1" in svtav1_params
+        assert "transfer-characteristics=16" in svtav1_params
+
+    def test_hdr_hlg_uses_correct_transfer_characteristics(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="hevc"),
+                FakeCompletedProcess(stdout="arib-std-b67"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert args[args.index("-color_trc") + 1] == "arib-std-b67"
+        svtav1_params = args[args.index("-svtav1-params") + 1]
+        assert "transfer-characteristics=18" in svtav1_params
+
+    def test_sdr_video_stays_8bit(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout="bt709"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert args[args.index("-pix_fmt") + 1] == "yuv420p"
+        assert "-svtav1-params" not in args
+        assert "-color_primaries" not in args
 
 
 class TestDetectVideoCodec:
@@ -450,6 +523,91 @@ class TestDetectVideoCodec:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.return_value = FakeCompletedProcess(stdout="hevc")
             detect_video_codec(str(video), timeouts=timeouts)
+
+        assert mock_run.call_args[1]["timeout"] == 7
+
+
+class TestDetectHdrTransfer:
+    def test_returns_transfer_for_pq(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="smpte2084")
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer == "smpte2084"
+
+    def test_returns_transfer_for_hlg(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="arib-std-b67")
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer == "arib-std-b67"
+
+    def test_returns_none_for_sdr(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="bt709")
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer is None
+
+    def test_returns_none_for_untagged_stream(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="")
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer is None
+
+    def test_returns_none_on_nonzero_exit(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(
+                returncode=1, stdout="smpte2084"
+            )
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer is None
+
+    def test_returns_none_on_timeout(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("ffprobe", 60)
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer is None
+
+    def test_returns_none_on_missing_binary(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("ffprobe not found")
+            transfer = detect_hdr_transfer(str(video))
+
+        assert transfer is None
+
+    def test_custom_probe_timeout(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        timeouts = Timeouts(probe=7)
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="smpte2084")
+            detect_hdr_transfer(str(video), timeouts=timeouts)
 
         assert mock_run.call_args[1]["timeout"] == 7
 


### PR DESCRIPTION
## What changed
- TIFF images now convert correctly (missing ImageMagick decode delegate) — fixes #113
- HDR10(+) and HLG video sources are re-encoded 10-bit with BT.2020 primaries instead of being flattened to 8-bit SDR — fixes #115

## Related issue
Fixes #113
Fixes #115

## Checklist
- [x] Focused, single-purpose change
- [x] Tested locally
- [x] CI passes