### PR TITLE
chore: bump version to 2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "immich-convert-originals"
-version = "2.0.0"
+version = "2.4.0"
 requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.141.1",


### PR DESCRIPTION
## What changed

Bump `pyproject.toml` version to 2.4.0 ahead of the v2.4.0 release (HDR10/HLG video support, TIFF conversion fix).

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally (pytest 229 passed, ruff check/format clean, mypy clean, Docker image builds and boots)
- [x] CI passes