### PR TITLE
fix(transcode): remap gbr/rgb SDR color metadata so SVT-AV1 accepts it

### DIFF
--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -165,6 +165,44 @@ def detect_hdr_transfer(path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS) -> str
         return None
 
 
+# ffprobe color_space values that require 4:4:4 chroma in SVT-AV1.
+# Older phone/WhatsApp encoders commonly mistag ordinary 4:2:0 SDR streams
+# this way (matrix_coefficients=0, "Identity"), rather than encoding genuine
+# RGB/4:4:4 content -- SVT-AV1 rejects the mismatch outright.
+IDENTITY_MATRIX_COLOR_SPACES = {"gbr", "rgb"}
+
+
+def detect_color_space(path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS) -> str | None:
+    """Detect video color space (matrix coefficients) using ffprobe."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=color_space",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeouts.probe,
+        )
+        if result.returncode == 0:
+            color_space = result.stdout.strip().lower()
+            return color_space if color_space else None
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("ffprobe timed out detecting color space for %s", path)
+        return None
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+
+
 def validate_output(path: str, expected_format: str) -> bool:
     """Validate output file exists, is non-zero, and has correct magic bytes."""
     if not os.path.exists(path):
@@ -444,6 +482,12 @@ def transcode_video(
     matching transfer characteristics carried through to the AV1 stream,
     instead of being flattened to 8-bit SDR. Everything else is unaffected.
 
+    SDR sources mistagged gbr/rgb (matrix_coefficients=0, "Identity" --
+    common on older phone/WhatsApp exports) have their color metadata
+    relabeled to bt709 before encoding, since SVT-AV1 otherwise refuses to
+    encode that tag outside 4:4:4 chroma even though the actual pixel data
+    is ordinary 4:2:0.
+
     Args:
         crf: Quality (0-63, lower=better)
         preset: Speed preset (0-13, lower=slower/better)
@@ -479,6 +523,7 @@ def transcode_video(
         )
 
     hdr_transfer = detect_hdr_transfer(input_path, timeouts=timeouts)
+    color_space = detect_color_space(input_path, timeouts=timeouts)
 
     cmd = [
         "ffmpeg",
@@ -493,14 +538,27 @@ def transcode_video(
         preset,
     ]
 
+    filters = []
+
     if max_dimension > 0:
         # Scale based on the shorter side (min of width/height)
         # This ensures portrait videos get proper resolution (e.g., 1080x1920 instead of 607x1080)
-        scale_filter = (
+        filters.append(
             f"scale='trunc(if(gt(min(iw,ih),{max_dimension}),iw*{max_dimension}/min(iw,ih),iw)/2)*2':"
             f"'trunc(if(gt(min(iw,ih),{max_dimension}),ih*{max_dimension}/min(iw,ih),ih)/2)*2'"
         )
-        cmd.extend(["-vf", scale_filter])
+
+    # Older phone/WhatsApp encoders commonly mistag ordinary 4:2:0 SDR streams
+    # as gbr/rgb (matrix_coefficients=0, "Identity"). SVT-AV1 refuses to
+    # encode that combination outside 4:4:4, so relabel (not convert) the
+    # frame metadata to a standard matrix before it reaches the encoder.
+    # The HDR branch below already sets its own explicit -colorspace, so this
+    # only matters for the SDR path.
+    if not hdr_transfer and color_space in IDENTITY_MATRIX_COLOR_SPACES:
+        filters.append("setparams=colorspace=bt709")
+
+    if filters:
+        cmd.extend(["-vf", ",".join(filters)])
 
     if hdr_transfer:
         svtav1_params = [

--- a/backend/app/services/transcode.py
+++ b/backend/app/services/transcode.py
@@ -165,10 +165,8 @@ def detect_hdr_transfer(path: str, timeouts: Timeouts = DEFAULT_TIMEOUTS) -> str
         return None
 
 
-# ffprobe color_space values that require 4:4:4 chroma in SVT-AV1.
-# Older phone/WhatsApp encoders commonly mistag ordinary 4:2:0 SDR streams
-# this way (matrix_coefficients=0, "Identity"), rather than encoding genuine
-# RGB/4:4:4 content -- SVT-AV1 rejects the mismatch outright.
+# ffprobe color_space values SVT-AV1 rejects outside 4:4:4 chroma.
+# Ordinary SDR mistagged gbr/rgb (matrix_coefficients=0, "Identity").
 IDENTITY_MATRIX_COLOR_SPACES = {"gbr", "rgb"}
 
 
@@ -482,11 +480,8 @@ def transcode_video(
     matching transfer characteristics carried through to the AV1 stream,
     instead of being flattened to 8-bit SDR. Everything else is unaffected.
 
-    SDR sources mistagged gbr/rgb (matrix_coefficients=0, "Identity" --
-    common on older phone/WhatsApp exports) have their color metadata
-    relabeled to bt709 before encoding, since SVT-AV1 otherwise refuses to
-    encode that tag outside 4:4:4 chroma even though the actual pixel data
-    is ordinary 4:2:0.
+    SDR sources mistagged gbr/rgb (matrix_coefficients=0, "Identity") are
+    relabeled to bt709, which SVT-AV1 accepts outside 4:4:4 chroma.
 
     Args:
         crf: Quality (0-63, lower=better)
@@ -548,12 +543,8 @@ def transcode_video(
             f"'trunc(if(gt(min(iw,ih),{max_dimension}),ih*{max_dimension}/min(iw,ih),ih)/2)*2'"
         )
 
-    # Older phone/WhatsApp encoders commonly mistag ordinary 4:2:0 SDR streams
-    # as gbr/rgb (matrix_coefficients=0, "Identity"). SVT-AV1 refuses to
-    # encode that combination outside 4:4:4, so relabel (not convert) the
-    # frame metadata to a standard matrix before it reaches the encoder.
-    # The HDR branch below already sets its own explicit -colorspace, so this
-    # only matters for the SDR path.
+    # Mistagged gbr/rgb SDR: relabel metadata to bt709 (HDR sets its own
+    # -colorspace below).
     if not hdr_transfer and color_space in IDENTITY_MATRIX_COLOR_SPACES:
         filters.append("setparams=colorspace=bt709")
 

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -7,6 +7,7 @@ import subprocess
 from app.services.transcode import (
     Timeouts,
     copy_metadata,
+    detect_color_space,
     detect_hdr_transfer,
     detect_video_codec,
     transcode,
@@ -360,6 +361,7 @@ class TestTranscodeVideo:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
                 FakeCompletedProcess(stdout=""),
+                FakeCompletedProcess(stdout=""),
                 FileNotFoundError("ffmpeg not found"),
             ]
             result = transcode_video(
@@ -377,6 +379,7 @@ class TestTranscodeVideo:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
                 FakeCompletedProcess(stdout=""),
                 subprocess.TimeoutExpired("ffmpeg", 43200),
             ]
@@ -397,6 +400,7 @@ class TestTranscodeVideo:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
                 FakeCompletedProcess(stdout=""),
+                FakeCompletedProcess(stdout=""),
                 FakeCompletedProcess(returncode=0),
             ]
             transcode_video(
@@ -411,9 +415,11 @@ class TestTranscodeVideo:
 
         codec_probe_call = mock_run.call_args_list[0]
         hdr_probe_call = mock_run.call_args_list[1]
-        video_call = mock_run.call_args_list[2]
+        color_space_probe_call = mock_run.call_args_list[2]
+        video_call = mock_run.call_args_list[3]
         assert codec_probe_call[1]["timeout"] == 11
         assert hdr_probe_call[1]["timeout"] == 11
+        assert color_space_probe_call[1]["timeout"] == 11
         assert video_call[1]["timeout"] == 99
 
     def test_hdr_pq_uses_10bit_and_bt2020(self, tmp_path):
@@ -425,6 +431,7 @@ class TestTranscodeVideo:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="hevc"),
                 FakeCompletedProcess(stdout="smpte2084"),
+                FakeCompletedProcess(stdout=""),
                 FakeCompletedProcess(returncode=0),
             ]
             result = transcode_video(
@@ -450,6 +457,7 @@ class TestTranscodeVideo:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="hevc"),
                 FakeCompletedProcess(stdout="arib-std-b67"),
+                FakeCompletedProcess(stdout=""),
                 FakeCompletedProcess(returncode=0),
             ]
             result = transcode_video(
@@ -471,6 +479,7 @@ class TestTranscodeVideo:
             mock_run.side_effect = [
                 FakeCompletedProcess(stdout="h264"),
                 FakeCompletedProcess(stdout="bt709"),
+                FakeCompletedProcess(stdout="bt709"),
                 FakeCompletedProcess(returncode=0),
             ]
             result = transcode_video(
@@ -482,6 +491,94 @@ class TestTranscodeVideo:
         assert args[args.index("-pix_fmt") + 1] == "yuv420p"
         assert "-svtav1-params" not in args
         assert "-color_primaries" not in args
+        assert "-vf" not in args
+
+    def test_gbr_sdr_source_remaps_colorspace(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
+                FakeCompletedProcess(stdout="gbr"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert "-vf" in args
+        assert args[args.index("-vf") + 1] == "setparams=colorspace=bt709"
+
+    def test_rgb_sdr_source_remaps_colorspace(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
+                FakeCompletedProcess(stdout="rgb"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert "-vf" in args
+        assert args[args.index("-vf") + 1] == "setparams=colorspace=bt709"
+
+    def test_gbr_sdr_source_combines_with_scale_filter(self, tmp_path):
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="h264"),
+                FakeCompletedProcess(stdout=""),
+                FakeCompletedProcess(stdout="gbr"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 1080, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        vf_value = args[args.index("-vf") + 1]
+        assert "scale=" in vf_value
+        assert vf_value.endswith(",setparams=colorspace=bt709")
+
+    def test_gbr_hdr_source_is_not_remapped(self, tmp_path):
+        # HDR branch sets its own explicit -colorspace, so the SDR-only
+        # identity-matrix workaround must not also fire here.
+        input_path = tmp_path / "input.mp4"
+        input_path.write_bytes(b"\x00" * 100)
+        output_path = tmp_path / "output.mp4"
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                FakeCompletedProcess(stdout="hevc"),
+                FakeCompletedProcess(stdout="smpte2084"),
+                FakeCompletedProcess(stdout="gbr"),
+                FakeCompletedProcess(returncode=0),
+            ]
+            result = transcode_video(
+                str(input_path), str(output_path), 30, "4", 0, "128k"
+            )
+
+        assert result.success is True
+        args = mock_run.call_args[0][0]
+        assert "-vf" not in args
+        assert args[args.index("-colorspace") + 1] == "bt2020nc"
 
 
 class TestDetectVideoCodec:
@@ -608,6 +705,79 @@ class TestDetectHdrTransfer:
         with patch("app.services.transcode.subprocess.run") as mock_run:
             mock_run.return_value = FakeCompletedProcess(stdout="smpte2084")
             detect_hdr_transfer(str(video), timeouts=timeouts)
+
+        assert mock_run.call_args[1]["timeout"] == 7
+
+
+class TestDetectColorSpace:
+    def test_returns_gbr_for_identity_matrix_stream(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="gbr")
+            color_space = detect_color_space(str(video))
+
+        assert color_space == "gbr"
+
+    def test_returns_bt709_for_normal_stream(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="bt709")
+            color_space = detect_color_space(str(video))
+
+        assert color_space == "bt709"
+
+    def test_returns_none_for_untagged_stream(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="")
+            color_space = detect_color_space(str(video))
+
+        assert color_space is None
+
+    def test_returns_none_on_nonzero_exit(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(returncode=1, stdout="gbr")
+            color_space = detect_color_space(str(video))
+
+        assert color_space is None
+
+    def test_returns_none_on_timeout(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("ffprobe", 60)
+            color_space = detect_color_space(str(video))
+
+        assert color_space is None
+
+    def test_returns_none_on_missing_binary(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("ffprobe not found")
+            color_space = detect_color_space(str(video))
+
+        assert color_space is None
+
+    def test_custom_probe_timeout(self, tmp_path):
+        video = tmp_path / "video.mp4"
+        video.write_bytes(b"\x00" * 10)
+
+        timeouts = Timeouts(probe=7)
+        with patch("app.services.transcode.subprocess.run") as mock_run:
+            mock_run.return_value = FakeCompletedProcess(stdout="gbr")
+            detect_color_space(str(video), timeouts=timeouts)
 
         assert mock_run.call_args[1]["timeout"] == 7
 

--- a/backend/tests/test_transcode_subprocess.py
+++ b/backend/tests/test_transcode_subprocess.py
@@ -558,8 +558,6 @@ class TestTranscodeVideo:
         assert vf_value.endswith(",setparams=colorspace=bt709")
 
     def test_gbr_hdr_source_is_not_remapped(self, tmp_path):
-        # HDR branch sets its own explicit -colorspace, so the SDR-only
-        # identity-matrix workaround must not also fire here.
         input_path = tmp_path / "input.mp4"
         input_path.write_bytes(b"\x00" * 100)
         output_path = tmp_path / "output.mp4"


### PR DESCRIPTION
## What changed

Older phone/WhatsApp encoders commonly tag ordinary 4:2:0 SDR H.264 streams with `matrix_coefficients=0` ("Identity"/`gbr`), even though the actual pixel data isn't RGB/4:4:4. SVT-AV1 has a hard validation that rejects that combination outright, so the video transcode step fails before a single frame is encoded:

```
Svt[error]: Identity matrix (matrix_coefficient = 0) may be used only with 4:4:4 color format.
[libsvtav1 @ 0x...] Error setting encoder parameters: bad parameter (0x80001005)
...
Conversion failed!
```

When ffprobe reports `color_space` `gbr`/`rgb` on an SDR source (the existing HDR branch already sets its own explicit `-colorspace`, so it's unaffected), this relabels the frame metadata to `bt709` via `-vf setparams=colorspace=bt709` before it reaches the encoder. This only retags the metadata — no pixel-level color conversion — and lets SVT-AV1 proceed normally on ordinary 4:2:0 content.

Fixes #121.

## Verification

- Reproduced the failure and confirmed the fix against a real affected file (an old WhatsApp export from my own library), using the exact ffmpeg/SVT-AV1 build the app ships in its Docker image: fails with the reported error without the filter, produces a valid, playable AV1 output with it.
- Ran the same comparison across 5 different affected files end-to-end (real download → transcode with the fix → visual side-by-side check against the originals) — all 5 converted successfully with no visible change in content, orientation, or audio, and typical AV1 size savings (47-74% smaller in this sample).
- Added a `TestDetectColorSpace` class mirroring the existing `TestDetectHdrTransfer` tests, plus new `TestTranscodeVideo` cases covering the gbr/rgb remap (standalone, combined with the scale filter, and confirming the HDR branch is unaffected).
- Updated existing `transcode_video` tests' mocked `subprocess.run` call sequences for the new probe call.
- Full backend test suite passes locally (`pytest backend/tests`, excluding the `integration` folder which needs real service dependencies not available in my sandbox).

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally — reproduced the bug and verified the fix against real affected files, plus full unit test suite
- [x] CI should pass (mirrors the existing HDR test patterns)
