### PR TITLE
fix(immich-client): use a separate, longer timeout for asset uploads

### DIFF
--- a/backend/app/services/immich_client.py
+++ b/backend/app/services/immich_client.py
@@ -47,6 +47,7 @@ class ImmichClient:
         retry_max: int = 3,
         retry_backoff: int = 2,
         timeout: tuple[int, int] = (10, 300),
+        upload_timeout: tuple[int, int] = (60, 300),
     ):
         self.api_base = api_base
         self.api_key = api_key
@@ -54,6 +55,13 @@ class ImmichClient:
         self.retry_backoff = retry_backoff
         self._default_headers = {"x-api-key": api_key}
         self._timeout = timeout  # (connect_timeout, read_timeout)
+        # Uploads stream the full converted file as the request body, so the
+        # connect-phase timeout also has to cover however long sending that
+        # body takes (requests/urllib3 keep the connect-timeout socket
+        # deadline in effect until the request has been fully sent, not just
+        # until the TCP handshake completes) -- a large file can easily take
+        # longer than the short timeout used for regular API calls.
+        self._upload_timeout = upload_timeout
 
     def _request_with_retry(self, method: str, url: str, **kwargs) -> requests.Response:
         last_error = None
@@ -301,7 +309,7 @@ class ImmichClient:
                         headers=self._default_headers,
                         files=files,
                         data=data,
-                        timeout=self._timeout,
+                        timeout=self._upload_timeout,
                     )
 
                     if response.status_code == 401:

--- a/backend/app/services/immich_client.py
+++ b/backend/app/services/immich_client.py
@@ -55,12 +55,6 @@ class ImmichClient:
         self.retry_backoff = retry_backoff
         self._default_headers = {"x-api-key": api_key}
         self._timeout = timeout  # (connect_timeout, read_timeout)
-        # Uploads stream the full converted file as the request body, so the
-        # connect-phase timeout also has to cover however long sending that
-        # body takes (requests/urllib3 keep the connect-timeout socket
-        # deadline in effect until the request has been fully sent, not just
-        # until the TCP handshake completes) -- a large file can easily take
-        # longer than the short timeout used for regular API calls.
         self._upload_timeout = upload_timeout
 
     def _request_with_retry(self, method: str, url: str, **kwargs) -> requests.Response:

--- a/backend/tests/test_immich_client.py
+++ b/backend/tests/test_immich_client.py
@@ -370,11 +370,6 @@ class TestUploadAsset:
         assert error is None
 
     def test_uses_upload_timeout_not_default_timeout(self, tmp_path):
-        # Uploads stream the whole converted file as the request body, so a
-        # large file can take much longer to send than the short
-        # connect-timeout used for regular (bodyless/small) API calls would
-        # allow -- upload_asset must use the separate, more generous
-        # upload_timeout instead of the client's general-purpose timeout.
         client = ImmichClient(
             api_base="https://example.com/api/",
             api_key="test_key",

--- a/backend/tests/test_immich_client.py
+++ b/backend/tests/test_immich_client.py
@@ -1,6 +1,7 @@
 """Tests for immich_api module using responses to mock HTTP."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -367,6 +368,32 @@ class TestUploadAsset:
         )
         assert asset_id == "new-asset-1"
         assert error is None
+
+    def test_uses_upload_timeout_not_default_timeout(self, tmp_path):
+        # Uploads stream the whole converted file as the request body, so a
+        # large file can take much longer to send than the short
+        # connect-timeout used for regular (bodyless/small) API calls would
+        # allow -- upload_asset must use the separate, more generous
+        # upload_timeout instead of the client's general-purpose timeout.
+        client = ImmichClient(
+            api_base="https://example.com/api/",
+            api_key="test_key",
+            timeout=(10, 300),
+            upload_timeout=(60, 300),
+        )
+        file_path = tmp_path / "upload.bin"
+        file_path.write_bytes(b"data")
+
+        with patch("app.services.immich_client.requests.request") as mock_request:
+            mock_request.return_value.status_code = 201
+            mock_request.return_value.json.return_value = {"id": "new-asset-1"}
+            client.upload_asset(
+                file_path=str(file_path),
+                file_created_at="2023-01-01T00:00:00Z",
+                file_modified_at="2023-01-01T00:00:00Z",
+            )
+
+        assert mock_request.call_args.kwargs["timeout"] == (60, 300)
 
     @responses.activate
     def test_retries_on_500(self, client, tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

`upload_asset` streams the whole converted file as the multipart request body, but was using the same short `(10, 300)` connect/read timeout as every other (small, bodyless-ish) API call.

`requests`/`urllib3` only have one timeout deadline on the underlying socket at a time: the connect-phase timeout stays in effect until the request has been **fully sent** — the read-timeout only takes over once the client starts waiting for the response. So any upload whose body takes longer than the connect-timeout to transmit fails outright, no matter how generous the read-timeout is.

Fixes #123.

## Verification

Reproduced directly against a real (idle, otherwise healthy) Immich instance, from inside the app's own container:

| Payload | Result |
|---|---|
| 10 MB (0.45s) | success |
| 200 MB (7.65s) | success |
| 500 MB (10.36s) | **fails** |
| 800 MB (10.85s) | **fails** |
| 1.2 GB (10.98s) | **fails** |

Failures cluster right at the ~10s connect-timeout, not scaling with payload size — confirming it's a hard ceiling, not a bandwidth/read-timeout issue. Raising just the connect-timeout to 120s made the same 1.2GB payload succeed in ~24s.

With this fix (a dedicated `upload_timeout=(60, 300)` used only by `upload_asset`), the same real 1.2GB file that had failed on every previous attempt (across several runs, both through a reverse proxy and a direct connection) uploaded successfully.

## Checklist

- [x] Focused, single-purpose change
- [x] Tested locally — reproduced the failure and verified the fix against a real Immich instance with real large files, plus full unit test suite (`pytest backend/tests`, excluding `integration/`)
- [x] CI should pass — added `TestUploadAsset.test_uses_upload_timeout_not_default_timeout` alongside the existing upload tests
